### PR TITLE
:sparkles: Feat: Novas sections (Detalhes - Jurídico)

### DIFF
--- a/src/components/Cards/DashbrokersCard.tsx
+++ b/src/components/Cards/DashbrokersCard.tsx
@@ -806,8 +806,6 @@ const DashbrokersCard = ({ oficio }:
 
     }, [mainData]);
 
-
-    console.log(oficio)
     /**
      * Define o tipo de indentificação do credor do ofício
      * que pode ser CPF ou CNPJ

--- a/src/components/CrmUi/InputFactory/index.tsx
+++ b/src/components/CrmUi/InputFactory/index.tsx
@@ -124,7 +124,7 @@ export const CelerInputField = React.memo(
                 );
             case InputFieldVariant.SELECT:
                 return (
-                    <div className="flex rounded-md gap-4 mt-2 w-full">
+                    <div className={cn("flex rounded-md gap-4 mt-2 w-full", props.className)}>
                         {props.iconSrc && <div className="flex items-center">{props.iconSrc}</div>}
                         <Select onValueChange={(selectedValue) => handleChange(selectedValue)} value={value} defaultValue={value} disabled={props.disabled || props.isLoading}>
                             <SelectTrigger className="shad-select-trigger">

--- a/src/components/Dashboard/Juridico.tsx
+++ b/src/components/Dashboard/Juridico.tsx
@@ -34,6 +34,9 @@ enum navItems {
   EM_LIQUIDACAO = "Em liquidação",
   EM_CESSAO = "Em cessão",
   REPACTUACAO = "Repactuação",
+  REVISAO_VALOR_LOA = "Revisão Valor/LOA",
+  PRE_DUE_ATIVO = "Pré-Due Ativo",
+  PRE_DUE_CEDENTE = "Pré-Due Cedente",
 }
 
 export type SimpleNotionData = {

--- a/src/components/Forms/EditOficioBrokerForm.tsx
+++ b/src/components/Forms/EditOficioBrokerForm.tsx
@@ -175,6 +175,7 @@ const EditOficioBrokerForm = ({ mainData }: IFormBroker): React.JSX.Element => {
             setValue("percentual_a_ser_adquirido", tFormatado);
             setValue("ja_possui_destacamento", mainData.properties["Honorários já destacados?"].checkbox);
             setValue("percentual_de_honorarios", mainData.properties["Percentual de Honorários Não destacados"].number! * 100 || 0);
+            setValue("nao_incide_selic_no_periodo_db_ate_abril", mainData.properties["Incide Selic Somente Sobre Principal"].checkbox)
             setValue("incidencia_rra_ir", mainData.properties["Incidencia RRA/IR"].checkbox);
             setValue("ir_incidente_rra", mainData.properties["IR Incidente sobre RRA"].checkbox);
             setValue("incidencia_pss", mainData.properties["PSS"].number! > 0);

--- a/src/components/Juridico/Details.tsx
+++ b/src/components/Juridico/Details.tsx
@@ -30,7 +30,7 @@ import { useForm } from "react-hook-form";
 import { AiOutlineLoading } from "react-icons/ai";
 import { BiInfoCircle, BiSave, BiSolidCalculator, BiSolidCoinStack, BiX } from "react-icons/bi";
 import { BsCalendar2HeartFill, BsPencilSquare } from "react-icons/bs";
-import { CgSearchLoading } from "react-icons/cg";
+import { CgArrowsH, CgSearchLoading } from "react-icons/cg";
 import { FaBalanceScale, FaIdCard, FaMapMarkedAlt, FaRegFilePdf } from "react-icons/fa";
 import { FaBuilding, FaBuildingColumns, FaLink, FaUser } from "react-icons/fa6";
 import { GiPayMoney, GiReceiveMoney, GiTakeMyMoney } from "react-icons/gi";
@@ -54,6 +54,7 @@ import { SelectItem } from "../ui/select";
 import verifyRequiredInputsToDue from "@/functions/juridico/verifyRequiredInputsToDue";
 import { AxiosError } from "axios";
 import ChartFive from "../Charts/ChartFive";
+import { TiArrowBack, TiArrowForward } from "react-icons/ti";
 
 type JuridicoDetailsProps = {
   id: string;
@@ -97,28 +98,36 @@ export const LegalDetails = ({ id }: JuridicoDetailsProps) => {
   const [happenedRecalculation, setHappenedRecalculation] = useState<boolean>(false);
   const [recalculationData, setRecalculationData] = useState<any>(null);
   const [isLoadingRecalculation, setIsLoadingRecalculation] = useState<boolean>(false);
-  const [loadingUpdateState, setLoadingUpdateState] = useState({
-    nomeCredor: false,
-    cpfCnpj: false,
-    npuOriginario: false,
-    npuPrecatorio: false,
-    juizoVara: false,
-    enteDevedor: false,
-    estadoEnteDevedor: false,
-    formValores: false,
-    sliderValores: false,
-    observacoes: false,
-    responsavel: false,
-    previsaoDePagamento: false,
-    linkDue: false,
-    revisaoCalculo: false,
-    espelhoOficio: false,
-    estoquePrecatorio: false,
-    estadoCivil: false,
-    certidaoEmitidas: false,
-    possuiProcessos: false,
-    returnDue: false
-  });
+  const [loadingUpdateState, setLoadingUpdateState] = useState<string | null>(null);
+  // const [loadingUpdateState, setLoadingUpdateState] = useState({
+  //   nomeCredor: false,
+  //   cpfCnpj: false,
+  //   npuOriginario: false,
+  //   npuPrecatorio: false,
+  //   juizoVara: false,
+  //   enteDevedor: false,
+  //   estadoEnteDevedor: false,
+  //   formValores: false,
+  //   sliderValores: false,
+  //   observacoes: false,
+  //   responsavel: false,
+  //   previsaoDePagamento: false,
+  //   linkDue: false,
+  //   revisaoCalculo: false,
+  //   espelhoOficio: false,
+  //   estoquePrecatorio: false,
+  //   estadoCivil: false,
+  //   certidaoEmitidas: false,
+  //   possuiProcessos: false,
+  //   returnDue: false,
+  //   oficioRequisitorio: false,
+  //   memoriaCalculo: false,
+  //   autosAtivo: false,
+  //   possuiRecurso: false,
+  //   certidaoReceita: false,
+  //   certidaoEnteDevedor: false,
+  //   relatorioResumido: false
+  // });
   const [editLock, setEditLock] = useState<boolean>(false);
   const [disabledSaveButton, setDisabledSaveButton] = useState<boolean>(true);
   const [sliderError, setSliderError] = useState<boolean>(false);
@@ -135,6 +144,512 @@ export const LegalDetails = ({ id }: JuridicoDetailsProps) => {
   const rentabilidadeSlideRef = useRef<HTMLInputElement>(null);
   const desembolsoSlideRef = useRef<HTMLInputElement>(null);
   const linkDueInputRef = useRef<HTMLInputElement>(null);
+
+  const handleCession = () => {
+    /** code here */
+  }
+
+  async function fetchData() {
+    const response = await api.get(`/api/notion-api/list/page/${id}/`);
+    return response.data;
+  }
+  async function fetchCedenteData(cedenteId: string) {
+    if (!cedenteId) return;
+    const response = await api.get(`/api/notion-api/list/page/${cedenteId}/`);
+    return response.data;
+  }
+
+  const { data, isLoading, refetch } = useQuery<NotionPage>({
+    queryKey: ["page", id],
+    queryFn: fetchData,
+    refetchOnWindowFocus: false
+  });
+
+  const { data: cedenteDataPF } = useQuery<NotionPage>({
+    queryKey: ["cedentePF", data?.properties['Cedente PF']?.relation?.[0]?.id],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+    queryFn: () => fetchCedenteData(data?.properties['Cedente PF']?.relation?.[0]?.id!),
+    refetchOnWindowFocus: false,
+    enabled: !!data?.properties['Cedente PF']?.relation?.[0]?.id
+  });
+
+  const { data: cedenteDataPJ } = useQuery<NotionPage>({
+    queryKey: ["cedentePJ", data?.properties['Cedente PJ']?.relation?.[0]?.id],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+    queryFn: () => fetchCedenteData(data?.properties['Cedente PJ']?.relation?.[0]?.id!),
+    refetchOnWindowFocus: false,
+    enabled: !!data?.properties['Cedente PJ']?.relation?.[0]?.id
+  });
+
+  const { data: socioData } = useQuery<NotionPage>({
+    queryKey: ["socio", cedenteDataPJ?.properties["Sócio Representante"]?.relation?.[0]?.id],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+    queryFn: () => fetchCedenteData(cedenteDataPJ?.properties["Sócio Representante"]?.relation?.[0]?.id!),
+    refetchOnWindowFocus: false,
+    enabled: !!cedenteDataPJ?.properties["Sócio Representante"]?.relation?.[0]?.id
+  });
+
+  const onSubmitForm = async (formData: any) => {
+    setIsLoadingRecalculation(true);
+    if (formData.observacao) {
+      formData.observacao = `
+💭 Comentários: ${formData.observacao}
+`
+    }
+
+    if (formData.valor_aquisicao_total) {
+      formData.percentual_a_ser_adquirido = 1;
+    } else {
+      formData.percentual_a_ser_adquirido = formData.percentual_a_ser_adquirido / 100;
+    }
+
+    if (!formData.ja_possui_destacamento) {
+      formData.percentual_de_honorarios = formData.percentual_de_honorarios / 100
+    }
+
+    if (typeof formData.valor_principal === "string") {
+      formData.valor_principal = backendNumberFormat(formData.valor_principal) || 0;
+      formData.valor_principal = parseFloat(formData.valor_principal);
+    }
+
+    if (typeof formData.valor_juros === "string") {
+      formData.valor_juros = backendNumberFormat(formData.valor_juros) || 0;
+      formData.valor_juros = parseFloat(formData.valor_juros);
+    }
+
+    if (formData.data_base) {
+      formData.data_base = formData.data_base.split("/").reverse().join("-");
+    }
+
+    if (formData.data_requisicao) {
+      formData.data_requisicao = formData.data_requisicao.split("/").reverse().join("-");
+    }
+
+    if (formData.data_limite_de_atualizacao) {
+      formData.data_limite_de_atualizacao = formData.data_limite_de_atualizacao.split("/").reverse().join("-");
+    }
+
+    if (typeof formData.valor_pss === "string") {
+      formData.valor_pss = backendNumberFormat(formData.valor_pss) || 0;
+      formData.valor_pss = parseFloat(formData.valor_pss);
+    }
+
+    if (!formData.ir_incidente_rra) {
+      formData.numero_de_meses = 0
+    } else {
+      formData.numero_de_meses = Number(formData.numero_de_meses)
+    }
+
+    if (!formData.incidencia_pss) {
+      formData.valor_pss = 0
+    }
+
+    if (!formData.data_limite_de_atualizacao_check) {
+      delete formData.data_limite_de_atualizacao_check
+    }
+
+    formData.upload_notion = true;
+    formData.need_to_recalculate_proposal = true;
+
+
+    swal.fire({
+      title: 'Confirmação',
+      text: 'Deseja enviar para repactuação?',
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonText: 'Sim. Enviar para repactuação',
+      cancelButtonText: 'Não. Somente atualizar',
+      confirmButtonColor: '#4CAF50',
+      cancelButtonColor: '#F44336',
+    }).then(async (result) => {
+      if (result.isConfirmed) {
+        formData.repactuar = true;
+      } else {
+        formData.repactuar = false;
+      }
+
+      try {
+        const response = await api.patch(`/api/juridico/update/precatorio/${id}/`, formData);
+        setHappenedRecalculation(true);
+        setRecalculationData(response.data);
+
+        swal.fire({
+          title: 'Sucesso',
+          text: 'Dados atualizados com sucesso!',
+          icon: 'success',
+          confirmButtonText: 'OK'
+        });
+
+        refetch();
+      } catch (error: AxiosError | any) {
+        swal.fire({
+          title: 'Erro',
+          text: `${error.response?.data?.detail || error.message}`,
+          icon: 'error',
+          confirmButtonText: 'OK'
+        })
+        console.error(error)
+      } finally {
+        setIsLoadingRecalculation(false);
+      }
+    })
+  }
+
+  const form = useForm();
+  const isFormModified = Object.keys(form.watch()).some((key) => form.watch()[key] !== formData?.[key]);
+
+  // TODO: documentar todas as funções desse componente com JSDocs
+  const handleChangeCreditorName = async (value: string, page_id: string) => {
+    await creditorNameMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  /**
+   * @description
+   * Essa função é utilizada para lidar com a mudança no campo de identificação (CPF/CNPJ)
+   * 
+   * @param {string} value - Valor do campo de identificação
+   * @param {string} page_id - ID da página do Notion
+   * @returns {Promise<void>}
+   */
+  const handleChangeIdentification = async (value: string, page_id: string): Promise<void> => {
+
+    if (value.length === 11) {
+      value = value.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
+    } else if (value.length === 14) {
+      value = value.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, "$1.$2.$3/$4-$5");
+    }
+
+    await identificationMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  /**
+   * @description
+   * Essa função é utilizada para lidar com a mudança no campo de NPU
+   * 
+   * @param {string} value - Valor do campo de NPU
+   * @param {string} type - Tipo do campo de NPU (ex: 'NPU')
+   * @param {string} page_id - ID da página do Notion
+   * @returns {Promise<void>}
+   */
+  const handleChangeNpu = async (value: string, type: string, page_id: string) => {
+
+    value = value.replace(/(\d{7})(\d{2})(\d{4})(\d{1})(\d{2})(\d{4})/, "$1-$2.$3.$4.$5.$6");
+
+    await npuMutation.mutateAsync({
+      page_id,
+      type,
+      value
+    });
+  }
+
+  const handleChangeJuizo = async (value: string, page_id: string) => {
+    await juizoMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  const handleChangeEnteDevedor = async (value: string, page_id: string) => {
+    await enteDevedorMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  const handleChangeEstadoEnteDevedor = async (value: string, page_id: string) => {
+    await estadoEnteDevedorMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  const handleChangeRentabilidadeSlider = (value: string, fromSlider?: boolean) => {
+
+    if (!value) return;
+    const sanitizedValue = value.replace(/%/g, "");
+
+    const newRentabilidade = !fromSlider ? Number(sanitizedValue) / 100 : Number(sanitizedValue);
+    const newDesembolso = handleDesembolsoVsRentabilidade(Number(newRentabilidade), data).desembolso;
+
+    if (newRentabilidade > 2 || newRentabilidade < 0) {
+
+      setSliderError(true);
+      return;
+
+    } else {
+      setSliderError(false);
+    }
+
+    setSliderValues({
+      rentabilidade: newRentabilidade,
+      desembolso: newDesembolso
+    })
+
+    if (rentabilidadeSlideRef.current && desembolsoSlideRef.current) {
+      rentabilidadeSlideRef.current.value = `${(newRentabilidade * 100).toFixed(2).replace(".", ",")}%`;
+      if (fromSlider) {
+        desembolsoSlideRef.current.value = numberFormat(newDesembolso);
+      }
+    }
+  }
+
+  const handleChangeDesembolsoSlider = (value: string, fromSlider?: boolean) => {
+
+    if (!value) return;
+    const rawValue = !fromSlider
+      ? Number(value.replace(/R\$\s*/g, "").replaceAll(".", "").replaceAll(",", "."))
+      : Number(value);
+
+    const newDesembolso = rawValue;
+    const newRentabilidade = findRentabilidadeAoAnoThroughDesembolso(Number(newDesembolso), data).rentabilidade_ao_ano;
+
+    if (newDesembolso > handleDesembolsoVsRentabilidade(0, data).desembolso
+      || newDesembolso < handleDesembolsoVsRentabilidade(2, data).desembolso) {
+
+      setSliderError(true);
+      return;
+
+    } else {
+      setSliderError(false);
+    }
+
+    setSliderValues({
+      rentabilidade: newRentabilidade,
+      desembolso: newDesembolso
+    })
+
+    if (rentabilidadeSlideRef.current && desembolsoSlideRef.current) {
+      desembolsoSlideRef.current.value = numberFormat(newDesembolso);
+      if (fromSlider) {
+        rentabilidadeSlideRef.current.value = `${(newRentabilidade * 100).toFixed(2).replace(".", ",")}%`;
+      }
+    }
+  }
+
+  const handleSaveValues = async () => {
+
+    setLoadingUpdateState("formValues");
+    try {
+      const factor = Math.pow(10, 5);
+      const newRentabilidade = Math.floor(sliderValues.rentabilidade * factor) / factor;
+      const res = await api.post(`/api/juridico/desembolso/${id}/`, {
+        rentabilidade_anual: newRentabilidade
+      });
+
+      if (res.status === 200) {
+        swal.fire({
+          toast: true,
+          timer: 3000,
+          timerProgressBar: true,
+          icon: 'success',
+          text: "Valores salvos com sucesso",
+          position: "bottom-right",
+          showConfirmButton: false,
+        })
+        refetch();
+      }
+
+    } catch (error) {
+      swal.fire({
+        toast: true,
+        timer: 3000,
+        timerProgressBar: true,
+        icon: 'error',
+        text: "Erro ao salvar os valores",
+        position: "bottom-right",
+        showConfirmButton: false,
+      })
+    } finally {
+      setLoadingUpdateState(null);
+    }
+
+  }
+
+  const handleUpdatePrevisaoDePagamento = async (value: string, page_id: string) => {
+    await previsaoDePagamentoMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  const handleUpdateObservation = async (value: string, page_id: string) => {
+    await observationMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  const handleUpdateDueLink = async (value: string, page_id: string) => {
+    await dueLinkMutation.mutateAsync({
+      page_id,
+      value
+    })
+  }
+
+  const handleCopyDueLink = () => {
+    if (linkDueInputRef.current) {
+      const value = linkDueInputRef.current.value;
+      navigator.clipboard.writeText(value);
+      navigator.vibrate(200);
+      setTimeout(() => setLinkCopied(false), 2000);
+    }
+  }
+
+  const handleUpdateRevisaoCalculo = async (value: boolean, page_id: string) => {
+    await revisaoCalculoMutation.mutateAsync({
+      value,
+      page_id
+    })
+  }
+
+  const handleUpdateEspelhoDoOficio = async (value: string, page_id: string) => {
+    await espelhoOficioMutation.mutateAsync({
+      value,
+      page_id
+    })
+  }
+
+  const handleUpdateEstoquePrecatorio = async (value: string, page_id: string) => {
+    await estoquePrecatoriosMutation.mutateAsync({
+      value,
+      page_id
+    })
+  }
+
+  const handleUpdateCertidoesEmitidas = async (value: string, page_id: string) => {
+    await certidaoEmitidaMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  const handleUpdatePossuiProcessos = async (value: string, page_id: string) => {
+    await possuiProcessosMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  const handleUpdateEstadoCivil = async (value: string, page_id: string) => {
+    await estadoCivilMutation.mutateAsync({
+      page_id,
+      value
+    });
+  }
+
+  const handleReturnDueRevision = async () => {
+    await returnDueRevisionMutation.mutateAsync({
+      page_id: id
+    });
+  }
+
+  const handleUpdateRevisaoChecks = async (value: boolean, page_id: string, type: string) => {
+    await revisãoOficioChecksMutation.mutateAsync({
+      value,
+      page_id,
+      type
+    })
+  }
+
+  const handleUpdateAutosAtivo = async (value: boolean, page_id: string) => {
+    await autosAtivoMutation.mutateAsync({
+      value,
+      page_id
+    })
+  }
+
+  const handleUpdateRecursoAutos = async (value: string, page_id: string) => {
+    await recursoAutosMutation.mutateAsync({
+      value,
+      page_id
+    })
+  }
+
+  const handleRepactuacao = () => {
+    swal.fire({
+      title: 'Repactuação',
+      text: 'Deseja mesmo Enviar para Repactuação?',
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonText: 'Sim',
+      cancelButtonText: 'Não',
+      confirmButtonColor: '#4CAF50',
+      cancelButtonColor: '#F44336',
+    }).then(async (result) => {
+      if (result.isConfirmed) {
+        const response = await api.patch(`api/notion-api/update/${id}/`, {
+          "Status Diligência": {
+            "select": {
+              "name": "Repactuação"
+            }
+          }
+        });
+        if (response.status !== 202) {
+          swal.fire({
+            title: 'Erro',
+            text: 'Houve um erro ao enviar para Repactuação',
+            icon: 'error',
+            confirmButtonText: 'OK'
+          });
+        }
+
+        refetch();
+
+        swal.fire({
+          title: 'Registro Salvo.',
+          text: 'O Oficio seguiu para a Repactuação.',
+          icon: 'success',
+          confirmButtonText: 'OK'
+        });
+      }
+    })
+  }
+
+  const handleUpdateDuePhase = async (phase: string) => {
+    swal.fire({
+      title: 'Mudança de Etapa',
+      text: 'Deseja enviar ofício para ' + phase + '?',
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonText: 'Sim',
+      cancelButtonText: 'Não',
+      confirmButtonColor: '#4CAF50',
+      cancelButtonColor: '#F44336',
+    }).then(async (result) => {
+      if (result.isConfirmed) {
+        const response = await api.patch(`api/notion-api/update/${id}/`, {
+          "Status Diligência": {
+            "select": {
+              "name": phase
+            }
+          }
+        });
+        if (response.status !== 202) {
+          swal.fire({
+            title: 'Erro',
+            text: 'Houve um erro ao enviar para ' + phase,
+            icon: 'error',
+            confirmButtonText: 'OK'
+          });
+        }
+
+        refetch();
+
+        swal.fire({
+          title: 'Registro Salvo.',
+          text: 'O Oficio seguiu para a ' + phase,
+          icon: 'success',
+          confirmButtonText: 'OK'
+        });
+      }
+    })
+  }
 
   const handleDueDiligence = () => {
     swal.fire({
@@ -448,413 +963,272 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     }
   }
 
-  const handleCession = () => {
-    /** code here */
-  }
-
-  async function fetchData() {
-    const response = await api.get(`/api/notion-api/list/page/${id}/`);
-    return response.data;
-  }
-  async function fetchCedenteData(cedenteId: string) {
-    if (!cedenteId) return;
-    const response = await api.get(`/api/notion-api/list/page/${cedenteId}/`);
-    return response.data;
-  }
-
-  const { data, isLoading, refetch } = useQuery<NotionPage>({
-    queryKey: ["page", id],
-    queryFn: fetchData,
-    refetchOnWindowFocus: false
-  });
-
-  const { data: cedenteDataPF } = useQuery<NotionPage>({
-    queryKey: ["cedentePF", data?.properties['Cedente PF']?.relation?.[0]?.id],
-    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-    queryFn: () => fetchCedenteData(data?.properties['Cedente PF']?.relation?.[0]?.id!),
-    refetchOnWindowFocus: false,
-    enabled: !!data?.properties['Cedente PF']?.relation?.[0]?.id
-  });
-
-  const { data: cedenteDataPJ} = useQuery<NotionPage>({
-    queryKey: ["cedentePJ", data?.properties['Cedente PJ']?.relation?.[0]?.id],
-    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-    queryFn: () => fetchCedenteData(data?.properties['Cedente PJ']?.relation?.[0]?.id!),
-    refetchOnWindowFocus: false,
-    enabled: !!data?.properties['Cedente PJ']?.relation?.[0]?.id
-  });
-
-  const { data: socioData } = useQuery<NotionPage>({
-    queryKey: ["socio", cedenteDataPJ?.properties["Sócio Representante"]?.relation?.[0]?.id],
-    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
-    queryFn: () => fetchCedenteData(cedenteDataPJ?.properties["Sócio Representante"]?.relation?.[0]?.id!),
-    refetchOnWindowFocus: false,
-    enabled: !!cedenteDataPJ?.properties["Sócio Representante"]?.relation?.[0]?.id
-  });
-
-  const onSubmitForm = async (formData: any) => {
-    setIsLoadingRecalculation(true);
-    if (formData.observacao) {
-      formData.observacao = `
-💭 Comentários: ${formData.observacao}
-`
-    }
-
-    if (formData.valor_aquisicao_total) {
-      formData.percentual_a_ser_adquirido = 1;
-    } else {
-      formData.percentual_a_ser_adquirido = formData.percentual_a_ser_adquirido / 100;
-    }
-
-    if (!formData.ja_possui_destacamento) {
-      formData.percentual_de_honorarios = formData.percentual_de_honorarios / 100
-    }
-
-    if (typeof formData.valor_principal === "string") {
-      formData.valor_principal = backendNumberFormat(formData.valor_principal) || 0;
-      formData.valor_principal = parseFloat(formData.valor_principal);
-    }
-
-    if (typeof formData.valor_juros === "string") {
-      formData.valor_juros = backendNumberFormat(formData.valor_juros) || 0;
-      formData.valor_juros = parseFloat(formData.valor_juros);
-    }
-
-    if (formData.data_base) {
-      formData.data_base = formData.data_base.split("/").reverse().join("-");
-    }
-
-    if (formData.data_requisicao) {
-      formData.data_requisicao = formData.data_requisicao.split("/").reverse().join("-");
-    }
-
-    if (formData.data_limite_de_atualizacao) {
-      formData.data_limite_de_atualizacao = formData.data_limite_de_atualizacao.split("/").reverse().join("-");
-    }
-
-    if (typeof formData.valor_pss === "string") {
-      formData.valor_pss = backendNumberFormat(formData.valor_pss) || 0;
-      formData.valor_pss = parseFloat(formData.valor_pss);
-    }
-
-    if (!formData.ir_incidente_rra) {
-      formData.numero_de_meses = 0
-    } else {
-      formData.numero_de_meses = Number(formData.numero_de_meses)
-    }
-
-    if (!formData.incidencia_pss) {
-      formData.valor_pss = 0
-    }
-
-    if (!formData.data_limite_de_atualizacao_check) {
-      delete formData.data_limite_de_atualizacao_check
-    }
-
-    formData.upload_notion = true;
-    formData.need_to_recalculate_proposal = true;
-
-
-    swal.fire({
-      title: 'Confirmação',
-      text: 'Deseja enviar para repactuação?',
-      icon: 'question',
-      showCancelButton: true,
-      confirmButtonText: 'Sim. Enviar para repactuação',
-      cancelButtonText: 'Não. Somente atualizar',
-      confirmButtonColor: '#4CAF50',
-      cancelButtonColor: '#F44336',
-    }).then(async (result) => {
-      if (result.isConfirmed) {
-        formData.repactuar = true;
-      } else {
-        formData.repactuar = false;
-      }
-
-      try {
-        const response = await api.patch(`/api/juridico/update/precatorio/${id}/`, formData);
-        setHappenedRecalculation(true);
-        setRecalculationData(response.data);
-
-        swal.fire({
-          title: 'Sucesso',
-          text: 'Dados atualizados com sucesso!',
-          icon: 'success',
-          confirmButtonText: 'OK'
-        });
-
-        refetch();
-      } catch (error: AxiosError | any) {
-        swal.fire({
-          title: 'Erro',
-          text: `${error.response?.data?.detail || error.message}`,
-          icon: 'error',
-          confirmButtonText: 'OK'
-        })
-        console.error(error)
-      } finally {
-        setIsLoadingRecalculation(false);
-      }
-    })
-  }
-
-  const form = useForm();
-  const isFormModified = Object.keys(form.watch()).some((key) => form.watch()[key] !== formData?.[key]);
-
-  // TODO: documentar todas as funções desse componente com JSDocs
-  const handleChangeCreditorName = async (value: string, page_id: string) => {
-    await creditorNameMutation.mutateAsync({
+  // TODO: Funções de handle que serão dinâmicas para um determinado grupo
+  // de campos do notion ficarão abaixo
+  const handleUpdateDataCheckbox = async (value: boolean, page_id: string, fieldName: string) => {
+    await updateNotionCheckboxMutation.mutateAsync({
+      value,
       page_id,
-      value
+      fieldName
     });
   }
 
-  /**
-   * @description
-   * Essa função é utilizada para lidar com a mudança no campo de identificação (CPF/CNPJ)
-   * 
-   * @param {string} value - Valor do campo de identificação
-   * @param {string} page_id - ID da página do Notion
-   * @returns {Promise<void>}
-   */
-  const handleChangeIdentification = async (value: string, page_id: string): Promise<void> => {
 
-    if (value.length === 11) {
-      value = value.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
-    } else if (value.length === 14) {
-      value = value.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, "$1.$2.$3/$4-$5");
-    }
+  // ----> Mutations <-----
 
-    await identificationMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
-
-  /**
-   * @description
-   * Essa função é utilizada para lidar com a mudança no campo de NPU
-   * 
-   * @param {string} value - Valor do campo de NPU
-   * @param {string} type - Tipo do campo de NPU (ex: 'NPU')
-   * @param {string} page_id - ID da página do Notion
-   * @returns {Promise<void>}
-   */
-  const handleChangeNpu = async (value: string, type: string, page_id: string) => {
-
-    value = value.replace(/(\d{7})(\d{2})(\d{4})(\d{1})(\d{2})(\d{4})/, "$1-$2.$3.$4.$5.$6");
-
-    await npuMutation.mutateAsync({
-      page_id,
-      type,
-      value
-    });
-  }
-
-  const handleChangeJuizo = async (value: string, page_id: string) => {
-    await juizoMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
-
-  const handleChangeEnteDevedor = async (value: string, page_id: string) => {
-    await enteDevedorMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
-
-  const handleChangeEstadoEnteDevedor = async (value: string, page_id: string) => {
-    await estadoEnteDevedorMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
-
-  const handleChangeRentabilidadeSlider = (value: string, fromSlider?: boolean) => {
-
-    if (!value) return;
-    const sanitizedValue = value.replace(/%/g, "");
-
-    const newRentabilidade = !fromSlider ? Number(sanitizedValue) / 100 : Number(sanitizedValue);
-    const newDesembolso = handleDesembolsoVsRentabilidade(Number(newRentabilidade), data).desembolso;
-
-    if (newRentabilidade > 2 || newRentabilidade < 0) {
-
-      setSliderError(true);
-      return;
-
-    } else {
-      setSliderError(false);
-    }
-
-    setSliderValues({
-      rentabilidade: newRentabilidade,
-      desembolso: newDesembolso
-    })
-
-    if (rentabilidadeSlideRef.current && desembolsoSlideRef.current) {
-      rentabilidadeSlideRef.current.value = `${(newRentabilidade * 100).toFixed(2).replace(".", ",")}%`;
-      if (fromSlider) {
-        desembolsoSlideRef.current.value = numberFormat(newDesembolso);
-      }
-    }
-  }
-
-  const handleChangeDesembolsoSlider = (value: string, fromSlider?: boolean) => {
-
-    if (!value) return;
-    const rawValue = !fromSlider
-      ? Number(value.replace(/R\$\s*/g, "").replaceAll(".", "").replaceAll(",", "."))
-      : Number(value);
-
-    const newDesembolso = rawValue;
-    const newRentabilidade = findRentabilidadeAoAnoThroughDesembolso(Number(newDesembolso), data).rentabilidade_ao_ano;
-
-    if (newDesembolso > handleDesembolsoVsRentabilidade(0, data).desembolso
-      || newDesembolso < handleDesembolsoVsRentabilidade(2, data).desembolso) {
-
-      setSliderError(true);
-      return;
-
-    } else {
-      setSliderError(false);
-    }
-
-    setSliderValues({
-      rentabilidade: newRentabilidade,
-      desembolso: newDesembolso
-    })
-
-    if (rentabilidadeSlideRef.current && desembolsoSlideRef.current) {
-      desembolsoSlideRef.current.value = numberFormat(newDesembolso);
-      if (fromSlider) {
-        rentabilidadeSlideRef.current.value = `${(newRentabilidade * 100).toFixed(2).replace(".", ",")}%`;
-      }
-    }
-  }
-
-  const handleSaveValues = async () => {
-
-    setLoadingUpdateState(prev => ({ ...prev, formValores: true }));
-    try {
-      const factor = Math.pow(10, 5);
-      const newRentabilidade = Math.floor(sliderValues.rentabilidade * factor) / factor;
-      const res = await api.post(`/api/juridico/desembolso/${id}/`, {
-        rentabilidade_anual: newRentabilidade
+  // TODO: mutations que serão dinâmicas para um determinado grupo
+  // de campos do notion ficarão abaixo
+  const updateNotionCheckboxMutation = useMutation({
+    mutationFn: async (paramsObj: { value: boolean, page_id: string, fieldName: string }) => {
+      const response = await api.patch(`api/notion-api/update/${paramsObj.page_id}/`, {
+        [paramsObj.fieldName]: {
+          "checkbox": paramsObj.value
+        }
       });
 
-      if (res.status === 200) {
-        swal.fire({
-          toast: true,
-          timer: 3000,
-          timerProgressBar: true,
-          icon: 'success',
-          text: "Valores salvos com sucesso",
-          position: "bottom-right",
-          showConfirmButton: false,
-        })
-        refetch();
+      if (response.status !== 202) {
+        throw new Error('houve um erro ao salvar os dados no notion');
       }
 
-    } catch (error) {
+      return response.data
+    },
+    onMutate: async (paramsObj) => {
+      setLoadingUpdateState(paramsObj.fieldName);
+      setEditLock(true);
+      const prevData = globalQueryClient.getQueryData(['page', id]);
+      globalQueryClient.setQueryData(['page', id], (prev: any) => {
+        return {
+          ...prev,
+          properties: {
+            ...prev?.properties,
+            [paramsObj.fieldName]: {
+              ...prev?.properties[paramsObj.fieldName],
+              checkbox: paramsObj.value
+            }
+          }
+        }
+      });
+      return { prevData }
+    },
+    onError: (error, paramsObj, context) => {
+      globalQueryClient.setQueryData(['page', id], context?.prevData);
       swal.fire({
         toast: true,
         timer: 3000,
         timerProgressBar: true,
         icon: 'error',
-        text: "Erro ao salvar os valores",
+        text: `Houve um erro ao atualizar o check de ${paramsObj.fieldName}`,
         position: "bottom-right",
         showConfirmButton: false,
-      })
-    } finally {
-      setLoadingUpdateState(prev => ({ ...prev, formValores: false }));
+      });
+    },
+    onSuccess: (data, paramsObj) => {
+      swal.fire({
+        toast: true,
+        timer: 3000,
+        timerProgressBar: true,
+        icon: 'success',
+        text: `Estado de ${paramsObj.fieldName} atualizado com sucesso!`,
+        position: "bottom-right",
+        showConfirmButton: false,
+      });
+    },
+    onSettled: (data, error, paramsObj) => {
+      setEditLock(false);
+      setLoadingUpdateState(null);
     }
+  })
 
-  }
 
-  const handleUpdatePrevisaoDePagamento = async (value: string, page_id: string) => {
-    await previsaoDePagamentoMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
 
-  const handleUpdateObservation = async (value: string, page_id: string) => {
-    await observationMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
+  const recursoAutosMutation = useMutation({
+    mutationFn: async (paramsObj: { value: string, page_id: string }) => {
+      const response = await api.patch(`api/notion-api/update/${paramsObj.page_id}/`, {
+        "Há algum recurso?": {
+          "select": {
+            "name": paramsObj.value
+          }
+        }
+      });
 
-  const handleUpdateDueLink = async (value: string, page_id: string) => {
-    await dueLinkMutation.mutateAsync({
-      page_id,
-      value
-    })
-  }
+      if (response.status !== 202) {
+        throw new Error('houve um erro ao salvar os dados no notion');
+      }
 
-  const handleCopyDueLink = () => {
-    if (linkDueInputRef.current) {
-      const value = linkDueInputRef.current.value;
-      navigator.clipboard.writeText(value);
-      navigator.vibrate(200);
-      setTimeout(() => setLinkCopied(false), 2000);
+      return response.data
+    },
+    onMutate: async (paramsObj) => {
+      setLoadingUpdateState("Há algum recurso?");
+      setEditLock(true);
+      const prevData = globalQueryClient.getQueryData(['page', id]);
+      globalQueryClient.setQueryData(['page', id], (prev: any) => {
+        return {
+          ...prev,
+          properties: {
+            ...prev?.properties,
+            "Há algum recurso?": {
+              ...prev?.properties["Há algum recurso?"],
+              select: {
+                ...prev?.properties["Há algum recurso?"]?.select,
+                name: paramsObj.value
+              }
+            }
+          }
+        }
+      });
+      return { prevData }
+    },
+    onError: (error, paramsObj, context) => {
+      globalQueryClient.setQueryData(['page', id], context?.prevData);
+      swal.fire({
+        toast: true,
+        timer: 3000,
+        timerProgressBar: true,
+        icon: 'error',
+        text: "Houve um erro ao atualizar o campo de recurso",
+        position: "bottom-right",
+        showConfirmButton: false,
+      });
+    },
+    onSuccess: () => {
+      swal.fire({
+        toast: true,
+        timer: 3000,
+        timerProgressBar: true,
+        icon: 'success',
+        text: "Estado de recursos atualizado com sucesso!",
+        position: "bottom-right",
+        showConfirmButton: false,
+      });
+    },
+    onSettled: () => {
+      setEditLock(false);
+      setLoadingUpdateState(null);
     }
-  }
+  })
 
-  const handleUpdateRevisaoCalculo = async (value: boolean, page_id: string) => {
-    await revisaoCalculoMutation.mutateAsync({
-      value,
-      page_id
-    })
-  }
+  const autosAtivoMutation = useMutation({
+    mutationFn: async (paramsObj: { value: boolean, page_id: string }) => {
+      const response = await api.patch(`api/notion-api/update/${paramsObj.page_id}/`, {
+        "Autos do Ativo Judicial Baixado": {
+          "checkbox": paramsObj.value
+        }
+      });
 
-  const handleUpdateEspelhoDoOficio = async (value: string, page_id: string) => {
-    await espelhoOficioMutation.mutateAsync({
-      value,
-      page_id
-    })
-  }
+      if (response.status !== 202) {
+        throw new Error('houve um erro ao salvar os dados no notion');
+      }
 
-  const handleUpdateEstoquePrecatorio = async (value: string, page_id: string) => {
-    await estoquePrecatoriosMutation.mutateAsync({
-      value,
-      page_id
-    })
-  }
+      return response.data
+    },
+    onMutate: async (paramsObj) => {
+      setLoadingUpdateState("Autos do Ativo Judicial Baixado");
+      setEditLock(true);
+      const prevData = globalQueryClient.getQueryData(['page', id]);
+      globalQueryClient.setQueryData(['page', id], (prev: any) => {
+        return {
+          ...prev,
+          properties: {
+            ...prev?.properties,
+            "Autos do Ativo Judicial Baixado": {
+              ...prev?.properties["Autos do Ativo Judicial Baixado"],
+              checkbox: paramsObj.value
+            }
+          }
+        }
+      });
+      return { prevData }
+    },
+    onError: (error, paramsObj, context) => {
+      globalQueryClient.setQueryData(['page', id], context?.prevData);
+      swal.fire({
+        toast: true,
+        timer: 3000,
+        timerProgressBar: true,
+        icon: 'error',
+        text: "Houve um erro ao atualizar o check de Autos do Ativo",
+        position: "bottom-right",
+        showConfirmButton: false,
+      });
+    },
+    onSuccess: () => {
+      swal.fire({
+        toast: true,
+        timer: 3000,
+        timerProgressBar: true,
+        icon: 'success',
+        text: "Estado de Autos do Ativo atualizado com sucesso!",
+        position: "bottom-right",
+        showConfirmButton: false,
+      });
+    },
+    onSettled: () => {
+      setEditLock(false);
+      setLoadingUpdateState(null);
+    }
+  })
 
-  const handleUpdateCertidoesEmitidas = async (value: string, page_id: string) => {
-    await certidaoEmitidaMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
+  const revisãoOficioChecksMutation = useMutation({
+    mutationFn: async (paramsObj: { value: boolean, page_id: string, type: string }) => {
+      const response = await api.patch(`api/notion-api/update/${paramsObj.page_id}/`, {
+        [paramsObj.type]: {
+          "checkbox": paramsObj.value
+        }
+      });
 
-  const handleUpdatePossuiProcessos = async (value: string, page_id: string) => {
-    await possuiProcessosMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
+      if (response.status !== 202) {
+        throw new Error('houve um erro ao salvar os dados no notion');
+      }
 
-  const handleUpdateEstadoCivil = async (value: string, page_id: string) => {
-    await estadoCivilMutation.mutateAsync({
-      page_id,
-      value
-    });
-  }
+      return response.data
+    },
+    onMutate: async (paramsObj) => {
+      setLoadingUpdateState(paramsObj.type);
+      setEditLock(true);
+      const prevData = globalQueryClient.getQueryData(['page', id]);
+      globalQueryClient.setQueryData(['page', id], (prev: any) => {
+        return {
+          ...prev,
+          properties: {
+            ...prev?.properties,
+            [paramsObj.type]: {
+              ...prev?.properties[paramsObj.type],
+              checkbox: paramsObj.value
+            }
+          }
+        }
+      });
+      return { prevData }
+    },
+    onError: (error, paramsObj, context) => {
+      globalQueryClient.setQueryData(['page', id], context?.prevData);
+      swal.fire({
+        toast: true,
+        timer: 3000,
+        timerProgressBar: true,
+        icon: 'error',
+        text: "Houve um erro ao atualizar o check de preenchimento",
+        position: "bottom-right",
+        showConfirmButton: false,
+      });
+    },
+    onSuccess: () => {
+      swal.fire({
+        toast: true,
+        timer: 3000,
+        timerProgressBar: true,
+        icon: 'success',
+        text: "Estado de preenchimento atualizado com sucesso!",
+        position: "bottom-right",
+        showConfirmButton: false,
+      });
+    },
+    onSettled: () => {
+      setEditLock(false);
+        setLoadingUpdateState(null);
+    }
+  })
 
-  const handleReturnDueRevision = async () => {
-    await returnDueRevisionMutation.mutateAsync({
-      page_id: id
-    });
-  }
-
-
-
-  // ----> Mutations <-----
   const returnDueRevisionMutation = useMutation({
     mutationFn: async (paramsObj: { page_id: string }) => {
       const response = await api.patch(`api/notion-api/update/${paramsObj.page_id}/`, {
@@ -872,7 +1246,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async (paramsObj) => {
-      setLoadingUpdateState(prev => ({ ...prev, returnDue: true }));
+      setLoadingUpdateState("Revisão de Due Diligence");
       setEditLock(true);
     },
     onError: () => {
@@ -899,7 +1273,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, returnDue: false }));
+      setLoadingUpdateState(null);
     }
   })
 
@@ -918,7 +1292,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async (paramsObj) => {
-      setLoadingUpdateState(prev => ({ ...prev, estoquePrecatorio: true }));
+      setLoadingUpdateState("Estoque de Precatórios Baixado");
       setEditLock(true);
       const prevData = globalQueryClient.getQueryData(['page', id]);
       globalQueryClient.setQueryData(['page', id], (old: NotionPage) => {
@@ -960,7 +1334,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, estoquePrecatorio: false }));
+      setLoadingUpdateState(null);
     }
   })
 
@@ -979,7 +1353,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async (paramsObj) => {
-      setLoadingUpdateState(prev => ({ ...prev, espelhoOficio: true }));
+      setLoadingUpdateState("Espelho do ofício");
       setEditLock(true);
       const prevData = globalQueryClient.getQueryData(['page', id]);
       globalQueryClient.setQueryData(['page', id], (old: NotionPage) => {
@@ -1021,7 +1395,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, espelhoOficio: false }));
+      setLoadingUpdateState(null);
     }
   })
 
@@ -1040,7 +1414,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async (paramsObj) => {
-      setLoadingUpdateState(prev => ({ ...prev, revisaoCalculo: true }));
+      setLoadingUpdateState("Cálculo Revisado");
       setEditLock(true);
       const prevData = globalQueryClient.getQueryData(['page', id]);
       globalQueryClient.setQueryData(['page', id], (old: NotionPage) => {
@@ -1082,7 +1456,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, revisaoCalculo: false }));
+      setLoadingUpdateState(null);
     }
   })
 
@@ -1106,7 +1480,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async () => {
-      setLoadingUpdateState(prev => ({ ...prev, linkDue: true }));
+      setLoadingUpdateState("Link de Due Diligence");
       setEditLock(true);
     },
     onError: () => {
@@ -1134,58 +1508,58 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, linkDue: false }));
+      setLoadingUpdateState(null);
     }
   });
 
-  const resposavelMutation = useMutation({
-    mutationFn: async (paramsObj: { page_id: string }) => {
-      const response = await api.patch(`api/notion-api/update/${paramsObj.page_id}/`, {
-        // pegar os responsáveis do ofício e adicionar o usuário logado. Exemplo: henrique, jarbas, joao, maria
-        "Responsável - Celer": {
-          "multi_select": [
-            {
-              "name": data?.properties["Responsável - Celer"]?.multi_select?.map((item: any) => item.name).join(",") + `${user}`
-            }
-          ]
-        }
-      });
-      if (response.status !== 202) {
-        throw new Error('houve um erro ao salvar os dados no notion');
-      }
-      return response.data
-    },
-    onMutate: async () => {
-      setLoadingUpdateState(prev => ({ ...prev, responsavel: true }));
-      setEditLock(true);
-    },
-    onError: () => {
-      swal.fire({
-        toast: true,
-        timer: 3000,
-        timerProgressBar: true,
-        icon: 'error',
-        text: "Houve um erro ao atualizar o campo Responsável",
-        position: "bottom-right",
-        showConfirmButton: false,
-      });
-    },
-    onSuccess: () => {
-      swal.fire({
-        toast: true,
-        timer: 3000,
-        timerProgressBar: true,
-        icon: 'success',
-        text: "Campo Responsável atualizado com sucesso",
-        position: "bottom-right",
-        showConfirmButton: false,
-      });
-    },
-    onSettled: () => {
-      setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, responsavel: false }));
-    }
-  });
+  // const resposavelMutation = useMutation({
+  //   mutationFn: async (paramsObj: { page_id: string }) => {
+  //     const response = await api.patch(`api/notion-api/update/${paramsObj.page_id}/`, {
+  //       // pegar os responsáveis do ofício e adicionar o usuário logado. Exemplo: henrique, jarbas, joao, maria
+  //       "Responsável - Celer": {
+  //         "multi_select": [
+  //           {
+  //             "name": data?.properties["Responsável - Celer"]?.multi_select?.map((item: any) => item.name).join(",") + `${user}`
+  //           }
+  //         ]
+  //       }
+  //     });
+  //     if (response.status !== 202) {
+  //       throw new Error('houve um erro ao salvar os dados no notion');
+  //     }
+  //     return response.data
+  //   },
+  //   onMutate: async () => {
+  //     setLoadingUpdateState(prev => ({ ...prev, responsavel: true }));
+  //     setEditLock(true);
+  //   },
+  //   onError: () => {
+  //     swal.fire({
+  //       toast: true,
+  //       timer: 3000,
+  //       timerProgressBar: true,
+  //       icon: 'error',
+  //       text: "Houve um erro ao atualizar o campo Responsável",
+  //       position: "bottom-right",
+  //       showConfirmButton: false,
+  //     });
+  //   },
+  //   onSuccess: () => {
+  //     swal.fire({
+  //       toast: true,
+  //       timer: 3000,
+  //       timerProgressBar: true,
+  //       icon: 'success',
+  //       text: "Campo Responsável atualizado com sucesso",
+  //       position: "bottom-right",
+  //       showConfirmButton: false,
+  //     });
+  //   },
+  //   onSettled: () => {
+  //     setEditLock(false);
+  //     setLoadingUpdateState(prev => ({ ...prev, responsavel: false }));
+  //   }
+  // });
 
   const creditorNameMutation = useMutation({
     mutationFn: async (paramsObj: { page_id: string, value: string }) => {
@@ -1207,7 +1581,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onMutate: async (paramsObj: any) => {
       setEditLock(true);
-      setLoadingUpdateState(prev => ({ ...prev, nomeCredor: true }));
+      setLoadingUpdateState("Credor");
     },
     onError: () => {
       swal.fire({
@@ -1233,7 +1607,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, nomeCredor: false }));
+      setLoadingUpdateState(null);
     }
   });
 
@@ -1256,7 +1630,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data;
     },
     onMutate: async (paramsObj: any) => {
-      setLoadingUpdateState(prev => ({ ...prev, observacoes: true }));
+      setLoadingUpdateState("Observação");
       setEditLock(true);
     },
     onError: () => {
@@ -1284,7 +1658,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, observacoes: false }));
+      setLoadingUpdateState(null);
     }
   });
 
@@ -1307,7 +1681,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data;
     },
     onMutate: async (paramsObj: any) => {
-      setLoadingUpdateState(prev => ({ ...prev, cpfCnpj: true }));
+      setLoadingUpdateState("CPF/CNPJ");
       setEditLock(true);
     },
     onError: () => {
@@ -1333,7 +1707,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       });
     },
     onSettled: () => {
-      setLoadingUpdateState(prev => ({ ...prev, cpfCnpj: false }));
+      setLoadingUpdateState(null);
       setEditLock(false);
     }
   });
@@ -1365,7 +1739,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data;
     },
     onMutate: async () => {
-      setLoadingUpdateState(prev => ({ ...prev, previsaoDePagamento: true }));
+      setLoadingUpdateState("Previsão de Pagamento");
       setEditLock(true);
     },
     onError: () => {
@@ -1392,7 +1766,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       refetch(); // refetch para atualizar o objeto do notion com a nova data
     },
     onSettled: () => {
-      setLoadingUpdateState(prev => ({ ...prev, previsaoDePagamento: false }));
+      setLoadingUpdateState(null);
       setEditLock(false);
     }
   });
@@ -1416,10 +1790,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async (paramsObj) => {
-      const npuType = paramsObj.type === "NPU (Originário)" ? "npuOriginario" : "npuPrecatorio"
-      setLoadingUpdateState(prev => ({ ...prev, [npuType]: true }));
-      setEditLock(true);
-      return { npuType };
+      setLoadingUpdateState(paramsObj.type);
     },
     onError: (error, paramsObj) => {
       swal.fire({
@@ -1443,11 +1814,9 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
         showConfirmButton: false,
       });
     },
-    onSettled: (data, error, paramsObj, context) => {
+    onSettled: () => {
       setEditLock(false);
-      if (context?.npuType) {
-        setLoadingUpdateState(prev => ({ ...prev, [context?.npuType]: false }));
-      }
+        setLoadingUpdateState(null);
     }
   });
 
@@ -1470,7 +1839,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async () => {
-      setLoadingUpdateState(prev => ({ ...prev, juizoVara: true }));
+      setLoadingUpdateState("Juízo");
       setEditLock(true);
     },
     onError: () => {
@@ -1497,7 +1866,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, juizoVara: false }));
+      setLoadingUpdateState(null);
     }
   });
 
@@ -1516,7 +1885,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async () => {
-      setLoadingUpdateState(prev => ({ ...prev, enteDevedor: true }));
+      setLoadingUpdateState("Ente Devedor");
       setEditLock(true);
     },
     onError: () => {
@@ -1543,7 +1912,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, enteDevedor: false }));
+      setLoadingUpdateState(null);
     }
   });
 
@@ -1562,7 +1931,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async () => {
-      setLoadingUpdateState(prev => ({ ...prev, estadoEnteDevedor: true }));
+      setLoadingUpdateState("Estado do Ente Devedor");
       setEditLock(true);
     },
     onError: () => {
@@ -1589,7 +1958,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, estadoEnteDevedor: false }));
+      setLoadingUpdateState(null);
     }
   });
 
@@ -1606,7 +1975,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async (paramsObj) => {
-      setLoadingUpdateState(prev => ({ ...prev, certidaoEmitidas: true }));
+      setLoadingUpdateState("Certidões emitidas");
       setEditLock(true);
       const prevData = globalQueryClient.getQueryData(['page', id]);
       globalQueryClient.setQueryData(['page', id], (old: NotionPage) => {
@@ -1648,7 +2017,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, certidaoEmitidas: false }));
+      setLoadingUpdateState(null);
     }
   });
 
@@ -1665,7 +2034,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async (paramsObj) => {
-      setLoadingUpdateState(prev => ({ ...prev, possuiProcessos: true }));
+      setLoadingUpdateState("Possui processos?");
       setEditLock(true);
       const prevData = globalQueryClient.getQueryData(['page', id]);
       globalQueryClient.setQueryData(['page', id], (old: NotionPage) => {
@@ -1707,7 +2076,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, possuiProcessos: false }));
+      setLoadingUpdateState(null);
     }
   });
 
@@ -1726,7 +2095,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
       return response.data
     },
     onMutate: async () => {
-      setLoadingUpdateState(prev => ({ ...prev, estadoCivil: true }));
+      setLoadingUpdateState("Estado Civil");
       setEditLock(true);
     },
     onError: () => {
@@ -1753,7 +2122,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
     },
     onSettled: () => {
       setEditLock(false);
-      setLoadingUpdateState(prev => ({ ...prev, estadoCivil: false }));
+      setLoadingUpdateState(null);
     }
   });
 
@@ -1840,6 +2209,8 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
 
   }, [data]);
 
+  console.log(data)
+
   if (!data) {
     return (
       <JuridicoDetailsSkeleton />
@@ -1872,7 +2243,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
                 iconAlt="user"
                 className="w-full"
                 onSubmit={(_, value) => handleChangeCreditorName(value, id)}
-                isLoading={loadingUpdateState.nomeCredor}
+                isLoading={loadingUpdateState === "Credor"}
                 disabled={editLock}
               />
             </div>
@@ -1895,137 +2266,140 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
                 iconAlt="document"
                 className="w-full"
                 onSubmit={(_, value) => handleChangeIdentification(value, id)}
-                isLoading={loadingUpdateState.cpfCnpj}
+                isLoading={loadingUpdateState === "CPF/CNPJ"}
                 disabled={editLock}
               />
             </div>
           </section>
 
-          <section id="cedentes" className="form-inputs-container">
-            <div className="col-span-4 w-full">
-              <h3 className="text-bodydark2 font-medium">
-                Informações sobre o cedente
-              </h3>
+          {(statusDiligence !== "Revisão Valor/LOA"
+            && statusDiligence !== "Pré-Due Ativo"
+          ) && (
+              <section id="cedentes" className="form-inputs-container">
+                <div className="col-span-4 w-full">
+                  <h3 className="text-bodydark2 font-medium">
+                    Informações sobre o cedente
+                  </h3>
 
-            </div>
-            <div className="col-span-4 gap-4">
-              <div className="grid grid-cols-6 gap-6">
-                <div className="grid min-w-40 md:col-span-3 lg:col-span-2 xl:col-span-1">
-                  <CelerInputField
-                    name="emissao_certidao_check"
-                    fieldType={InputFieldVariant.SELECT}
-                    label={`Certidões Emitidas ?`}
-                    defaultValue={data?.properties["Certidões emitidas"]?.checkbox ? "SIM" : "NÃO"}
-                    onValueChange={(_, value) => handleUpdateCertidoesEmitidas(value, id)}
-                    isLoading={loadingUpdateState.certidaoEmitidas}
-                    disabled={editLock}
-                    className="w-full"
-                  >
-                    <SelectItem value="SIM">Sim</SelectItem>
-                    <SelectItem value="NÃO">Não</SelectItem>
-                  </CelerInputField>
-
-                  {(!data?.properties["Certidões emitidas"]?.checkbox && requiredDueInputsError) && (
-                    <p className="text-red-500 dark:text-red-400 text-xs mt-2">Campo obrigatório para due</p>
-                  )}
                 </div>
-
-                <div className="grid min-w-40 md:col-span-3 lg:col-span-2 xl:col-span-1">
-                  <CelerInputField
-                    name="possui_processos_check"
-                    fieldType={InputFieldVariant.SELECT}
-                    label={`Possui Processos ?`}
-                    defaultValue={data?.properties["Possui processos?"]?.checkbox ? "SIM" : "NÃO"}
-                    onValueChange={(_, value) => handleUpdatePossuiProcessos(value, id)}
-                    isLoading={loadingUpdateState.possuiProcessos}
-                    disabled={editLock}
-                    className="w-full"
-                  >
-                    <SelectItem value="SIM">Sim</SelectItem>
-                    <SelectItem value="NÃO">Não</SelectItem>
-                  </CelerInputField>
-
-                  {(!data?.properties["Possui processos?"]?.checkbox && requiredDueInputsError) && (
-                    <p className="text-red-500 dark:text-red-400 text-xs mt-2">Campo obrigatório para due</p>
-                  )}
-                </div>
-
-                <div className="grid 2xsm:w-full md:w-115 md:col-span-6 xl:col-span-2">
-                  <CelerInputField
-                    className="w-full gap-2"
-                    fieldType={InputFieldVariant.SELECT}
-                    name="regime_casamento"
-                    label="Estado Civil"
-                    iconSrc={<BsCalendar2HeartFill />}
-                    defaultValue={
-                      credorIdentificationType === "CPF"
-                        ? cedenteDataPF?.properties["Estado Civil"]?.select?.name || ''
-                        : socioData?.properties["Estado Civil"]?.select?.name || ''
-                    }
-                    onValueChange={(_, value) => handleUpdateEstadoCivil(value,
-                      credorIdentificationType === "CPF"
-                        ? cedenteDataPF?.id!
-                        : socioData?.id!
-                    )}
-                    isLoading={loadingUpdateState.estadoCivil}
-                    disabled={editLock}
-                  >
-                    {tipoRegime.map((item, index) => (
-                      <SelectItem
-                        defaultChecked={
-                          credorIdentificationType === "CPF"
-                            ? cedenteDataPF?.properties["Estado Civil"]?.select?.name === item
-                            : socioData?.properties["Estado Civil"]?.select?.name === item
-                        }
-                        key={index}
-                        value={item}
+                <div className="col-span-4 gap-4">
+                  <div className="grid grid-cols-6 gap-6">
+                    <div className="grid min-w-40 md:col-span-3 lg:col-span-2 xl:col-span-1">
+                      <CelerInputField
+                        name="emissao_certidao_check"
+                        fieldType={InputFieldVariant.SELECT}
+                        label={`Certidões Emitidas ?`}
+                        defaultValue={data?.properties["Certidões emitidas"]?.checkbox ? "SIM" : "NÃO"}
+                        onValueChange={(_, value) => handleUpdateCertidoesEmitidas(value, id)}
+                        isLoading={loadingUpdateState === "Certidões emitidas"}
+                        disabled={editLock}
+                        className="w-full"
                       >
-                        {item}
-                      </SelectItem>
-                    ))}
-                  </CelerInputField>
+                        <SelectItem value="SIM">Sim</SelectItem>
+                        <SelectItem value="NÃO">Não</SelectItem>
+                      </CelerInputField>
 
-                  {credorIdentificationType === "CPF" && !cedenteDataPF?.properties["Estado Civil"]?.select?.name && requiredDueInputsError && (
-                    <p className="text-red-500 dark:text-red-400 text-xs mt-2">Campo obrigatório para due</p>
-                  )}
+                      {(!data?.properties["Certidões emitidas"]?.checkbox && requiredDueInputsError) && (
+                        <p className="text-red-500 dark:text-red-400 text-xs mt-2">Campo obrigatório para due</p>
+                      )}
+                    </div>
 
-                  {credorIdentificationType === "CNPJ" && !socioData?.properties["Estado Civil"]?.select?.name && requiredDueInputsError && (
-                    <p className="text-red-500 dark:text-red-400 text-xs mt-2">Campo obrigatório para due</p>
-                  )}
+                    <div className="grid min-w-40 md:col-span-3 lg:col-span-2 xl:col-span-1">
+                      <CelerInputField
+                        name="possui_processos_check"
+                        fieldType={InputFieldVariant.SELECT}
+                        label={`Possui Processos ?`}
+                        defaultValue={data?.properties["Possui processos?"]?.checkbox ? "SIM" : "NÃO"}
+                        onValueChange={(_, value) => handleUpdatePossuiProcessos(value, id)}
+                        isLoading={loadingUpdateState === "Possui processos?"}
+                        disabled={editLock}
+                        className="w-full"
+                      >
+                        <SelectItem value="SIM">Sim</SelectItem>
+                        <SelectItem value="NÃO">Não</SelectItem>
+                      </CelerInputField>
+
+                      {(!data?.properties["Possui processos?"]?.checkbox && requiredDueInputsError) && (
+                        <p className="text-red-500 dark:text-red-400 text-xs mt-2">Campo obrigatório para due</p>
+                      )}
+                    </div>
+
+                    <div className="grid 2xsm:w-full md:w-115 md:col-span-6 xl:col-span-2">
+                      <CelerInputField
+                        className="w-full gap-2"
+                        fieldType={InputFieldVariant.SELECT}
+                        name="regime_casamento"
+                        label="Estado Civil"
+                        iconSrc={<BsCalendar2HeartFill />}
+                        defaultValue={
+                          credorIdentificationType === "CPF"
+                            ? cedenteDataPF?.properties["Estado Civil"]?.select?.name || ''
+                            : socioData?.properties["Estado Civil"]?.select?.name || ''
+                        }
+                        onValueChange={(_, value) => handleUpdateEstadoCivil(value,
+                          credorIdentificationType === "CPF"
+                            ? cedenteDataPF?.id!
+                            : socioData?.id!
+                        )}
+                        isLoading={loadingUpdateState === "Estado Civil"}
+                        disabled={editLock}
+                      >
+                        {tipoRegime.map((item, index) => (
+                          <SelectItem
+                            defaultChecked={
+                              credorIdentificationType === "CPF"
+                                ? cedenteDataPF?.properties["Estado Civil"]?.select?.name === item
+                                : socioData?.properties["Estado Civil"]?.select?.name === item
+                            }
+                            key={index}
+                            value={item}
+                          >
+                            {item}
+                          </SelectItem>
+                        ))}
+                      </CelerInputField>
+
+                      {credorIdentificationType === "CPF" && !cedenteDataPF?.properties["Estado Civil"]?.select?.name && requiredDueInputsError && (
+                        <p className="text-red-500 dark:text-red-400 text-xs mt-2">Campo obrigatório para due</p>
+                      )}
+
+                      {credorIdentificationType === "CNPJ" && !socioData?.properties["Estado Civil"]?.select?.name && requiredDueInputsError && (
+                        <p className="text-red-500 dark:text-red-400 text-xs mt-2">Campo obrigatório para due</p>
+                      )}
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-            <div className="col-span-4 gap-4">
+                <div className="col-span-4 gap-4">
 
-              <div className="flex items-center gap-4">
+                  <div className="flex items-center gap-4">
 
-                <button
-                  onClick={() => data && setCedenteModal(data)}
-                  className="border border-strokedark/20 dark:border-stroke/20 dark:text-white text-slate-600 py-2 px-4 rounded-md flex items-center gap-3 uppercase text-sm font-medium hover:bg-strokedark/20 dark:hover:bg-stroke/20 transition-colors duration-200"
-                >
-                  {(data?.properties["Cedente PF"].relation?.[0] || data?.properties["Cedente PJ"].relation?.[0]) ? (
-                    <>
-                      <BsPencilSquare />
-                      Editar Cedente
-                    </>
-                  ) : (
-                    <>
-                      <GrDocumentUser />
-                      Cadastrar Cedente
-                    </>
-                  )}
-                </button>
-                <button
-                  onClick={() => data && setDocModalInfo(data)}
-                  className="border border-strokedark/20 dark:border-stroke/20 dark:text-white text-slate-600 py-2 px-4 rounded-md flex items-center gap-3 uppercase text-sm font-medium hover:bg-strokedark/20 dark:hover:bg-stroke/20 transition-colors duration-200"
-                >
-                  <FaRegFilePdf />
-                  Gerir Documentos
-                </button>
-              </div>
-            </div>
-          </section>
-
+                    <button
+                      onClick={() => data && setCedenteModal(data)}
+                      className="border border-strokedark/20 dark:border-stroke/20 dark:text-white text-slate-600 py-2 px-4 rounded-md flex items-center gap-3 uppercase text-sm font-medium hover:bg-strokedark/20 dark:hover:bg-stroke/20 transition-colors duration-200"
+                    >
+                      {(data?.properties["Cedente PF"].relation?.[0] || data?.properties["Cedente PJ"].relation?.[0]) ? (
+                        <>
+                          <BsPencilSquare />
+                          Editar Cedente
+                        </>
+                      ) : (
+                        <>
+                          <GrDocumentUser />
+                          Cadastrar Cedente
+                        </>
+                      )}
+                    </button>
+                    <button
+                      onClick={() => data && setDocModalInfo(data)}
+                      className="border border-strokedark/20 dark:border-stroke/20 dark:text-white text-slate-600 py-2 px-4 rounded-md flex items-center gap-3 uppercase text-sm font-medium hover:bg-strokedark/20 dark:hover:bg-stroke/20 transition-colors duration-200"
+                    >
+                      <FaRegFilePdf />
+                      Gerir Documentos
+                    </button>
+                  </div>
+                </div>
+              </section>
+            )}
 
           <section className="form-inputs-container" id="info_processo">
             <div className="2xsm:col-span-4 md:col-span-2 xl:col-span-1">
@@ -2038,7 +2412,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
                 iconAlt="law"
                 className="w-full"
                 onSubmit={(_, value) => handleChangeNpu(value, "NPU (Originário)", id)}
-                isLoading={loadingUpdateState.npuOriginario}
+                isLoading={loadingUpdateState === "NPU (Originário)"}
                 disabled={editLock}
               />
             </div>
@@ -2052,7 +2426,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
                 iconAlt="law"
                 className="w-full"
                 onSubmit={(_, value) => handleChangeNpu(value, "NPU (Precatório)", id)}
-                isLoading={loadingUpdateState.npuPrecatorio}
+                isLoading={loadingUpdateState === "NPU (Precatório)"}
                 disabled={editLock}
               />
             </div>
@@ -2066,7 +2440,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
                 iconAlt="law"
                 className="w-full"
                 onSubmit={(_, value) => handleChangeJuizo(value, id)}
-                isLoading={loadingUpdateState.juizoVara}
+                isLoading={loadingUpdateState === "Juizo"}
                 disabled={editLock}
               />
             </div>
@@ -2080,7 +2454,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
                 iconAlt="law"
                 className="w-full"
                 onSubmit={(_, value) => handleChangeEnteDevedor(value, id)}
-                isLoading={loadingUpdateState.enteDevedor}
+                isLoading={loadingUpdateState === "Ente Devedor"}
                 disabled={editLock}
               />
             </div>
@@ -2094,7 +2468,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
                 iconAlt="law"
                 className="w-full"
                 onValueChange={(_, value) => handleChangeEstadoEnteDevedor(value, id)}
-                isLoading={loadingUpdateState.estadoEnteDevedor}
+                isLoading={loadingUpdateState === "Estado do Ente Devedor"}
                 disabled={editLock}
               >
                 {estados.map(estado => (
@@ -2506,7 +2880,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
             ref={linkDueInputRef}
             fieldType={InputFieldVariant.INPUT}
             placeholder="Digite o link"
-            isLoading={loadingUpdateState.linkDue}
+            isLoading={loadingUpdateState === "Link de Due Diligence"}
             defaultValue={data?.properties["Link de Due Diligence"]?.url || "Sem link disponível"}
             className="2xsm:wfull md:w-100 !h-10"
             onSubmit={(_, value) => handleUpdateDueLink(value, id)}
@@ -2541,7 +2915,123 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
         </div>
       </section>
 
-      <section id="cedentes" className="grid gap-6 p-4 rounded-md bg-white dark:bg-boxdark">
+      {statusDiligence === "Revisão Valor/LOA" && (
+        <section id="revisao_preco_pagamento" className="p-4 rounded-md bg-white dark:bg-boxdark">
+          <h3 className="text-bodydark2 font-medium mb-8">
+            Revisão de Preço e Tempo de Pagamento
+          </h3>
+          <div className="flex gap-6">
+
+            <CelerInputField
+              name="preenchimento_oficio_requisitorio"
+              fieldType={InputFieldVariant.CHECKBOX}
+              checked={data?.properties["Preenchimento Correto"].checkbox}
+              label="Preenchimento de acordo com o Oficio Requisitorio"
+              isLoading={loadingUpdateState === "Preenchimento Correto"}
+              disabled={editLock}
+              onValueChange={(_, value) => handleUpdateRevisaoChecks(value, id, "Preenchimento Correto")}
+              className="text-sm font-medium"
+            />
+
+            <CelerInputField
+              name="memoria_calculo"
+              fieldType={InputFieldVariant.CHECKBOX}
+              checked={data?.properties["Memória de Cálculo"].checkbox}
+              label="Memória de cálculo de acordo com o ofício"
+              isLoading={loadingUpdateState === "Memória de Cálculo"}
+              disabled={editLock}
+              onValueChange={(_, value) => handleUpdateRevisaoChecks(value, id, "Memória de Cálculo")}
+              className="text-sm font-medium"
+            />
+          </div>
+        </section>
+      )}
+
+      {statusDiligence === "Pré-Due Ativo" && (
+        <section id="revisao_preco_pagamento" className="p-4 rounded-md bg-white dark:bg-boxdark">
+          <h3 className="text-bodydark2 font-medium mb-8 max-w-sm">
+            Revisão do Ativo Pré-Due
+          </h3>
+          <div className="flex flex-col gap-4">
+
+            <CelerInputField
+              name="autos_do_ativo_check"
+              fieldType={InputFieldVariant.CHECKBOX}
+              checked={data?.properties["Autos do Ativo Judicial Baixado"].checkbox}
+              label="Autos do Ativo Judicial Baixado"
+              isLoading={loadingUpdateState === "Autos do Ativo Judicial Baixado"}
+              disabled={editLock}
+              onValueChange={(_, value) => handleUpdateAutosAtivo(value, id)}
+              className="text-sm font-medium"
+            />
+
+            <hr className="border border-stroke dark:border-strokedark" />
+
+            <CelerInputField
+              name="possiu_recurso"
+              fieldType={InputFieldVariant.SELECT}
+              label={`Há algum recurso ?`}
+              defaultValue={data?.properties["Há algum recurso?"].select?.name || ""}
+              onValueChange={(_, value) => handleUpdateRecursoAutos(value, id)}
+              isLoading={loadingUpdateState === "Há algum recurso?"}
+              disabled={editLock}
+              className="max-w-[230px]"
+            >
+              <SelectItem value="Não">Não</SelectItem>
+              <SelectItem value="Sim sobre o valor total">Sim, sobre o valor total</SelectItem>
+              <SelectItem value="Sim sobre o valor parcial">Sim, sobre o valor parcial</SelectItem>
+            </CelerInputField>
+          </div>
+        </section>
+      )}
+
+      {statusDiligence === "Pré-Due Cedente" && (
+        <section id="revisao_preco_pagamento" className="p-4 rounded-md bg-white dark:bg-boxdark">
+          <h3 className="text-bodydark2 font-medium mb-8 max-w-sm">
+            Revisão do Cedente Pré-Due
+          </h3>
+          <div className="flex flex-col gap-4">
+
+            <CelerInputField
+              name="certidao_receita_federal"
+              fieldType={InputFieldVariant.CHECKBOX}
+              checked={data?.properties["Certidão Receita Federal/PGFN"].checkbox}
+              label="Certidão Receita Federal/PGFN"
+              isLoading={loadingUpdateState === "Certidão Receita Federal/PGFN"}
+              disabled={editLock}
+              onValueChange={(_, value) => handleUpdateDataCheckbox(value, id, "Certidão Receita Federal/PGFN")}
+              className="text-sm font-medium"
+            />
+
+            {data?.properties["Esfera"].select?.name !== "FEDERAL" && (
+              <CelerInputField
+                name="certidao_ente_devedor"
+                fieldType={InputFieldVariant.CHECKBOX}
+                checked={data?.properties["Certidão do Ente Devedor"].checkbox}
+                label="Certidão do Ente Devedor"
+                isLoading={loadingUpdateState === "Certidão do Ente Devedor"}
+                disabled={editLock}
+                onValueChange={(_, value) => handleUpdateDataCheckbox(value, id, "Certidão do Ente Devedor")}
+                className="text-sm font-medium"
+              />
+            )}
+
+            <CelerInputField
+              name="relatorio_resumido_processual"
+              fieldType={InputFieldVariant.CHECKBOX}
+              checked={data?.properties["Relatório Resumido Processual"].checkbox}
+              label="Relatório Resumido Processual"
+              isLoading={loadingUpdateState === "Relatório Resumido Processual"}
+              disabled={editLock}
+              onValueChange={(_, value) => handleUpdateDataCheckbox(value, id, "Relatório Resumido Processual")}
+              className="text-sm font-medium"
+            />
+
+          </div>
+        </section>
+      )}
+
+      <section id="precatorio_detalhes" className="grid gap-6 p-4 rounded-md bg-white dark:bg-boxdark">
         <h3 className="text-bodydark2 font-medium">
           Detalhes do precatório
         </h3>
@@ -2788,156 +3278,161 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
             fieldType={InputFieldVariant.CHECKBOX}
             checked={data?.properties["Cálculo Revisado"].checkbox}
             label="Cálculo Revisado"
-            isLoading={loadingUpdateState.revisaoCalculo}
+            isLoading={loadingUpdateState === "Cálculo Revisado"}
             onValueChange={(_, value) => handleUpdateRevisaoCalculo(value, id)}
             className="text-sm font-medium"
           />
         </div>
       </section>
 
-      <section id="valores_grafico">
-        <div className="grid 2xsm:grid-cols-2 xl:grid-cols-12 gap-4 md:gap-6 2xl:gap-7.5">
-          {/*
+      {(statusDiligence !== "Revisão Valor/LOA"
+        && statusDiligence !== "Pré-Due Ativo"
+        && statusDiligence !== "Pré-Due Cedente") && (
+          <section id="valores_grafico">
+            <div className="grid 2xsm:grid-cols-2 xl:grid-cols-12 gap-4 md:gap-6 2xl:gap-7.5">
+              {/*
           Deve ser feita uma verificação em "Data de aquisição do precatório" para que o gráfico seja exibido ou não - situação em que o precatório ainda não foi adquirido. Caso não tenha sido adquirido, o gráfico não deve ser exibido, ficando apenas uma div opaca com a mensagem "Gráfico de rentabilidade indisponível".
           */}
-          <div className="col-span-8 3xl:col-span-8">
-            <RentabilityChart data={vlData} />
-          </div>
-          <div className=" 2xsm:col-span-8 xl:col-span-4 3xl:col-span-4 flex flex-col gap-6 bg-white dark:bg-boxdark p-4 rounded-md">
-            <h2 className="text-xl font-medium">Rentabilidade x Desembolso</h2>
+              <div className="col-span-8 3xl:col-span-8">
+                <RentabilityChart data={vlData} />
+              </div>
+              <div className=" 2xsm:col-span-8 xl:col-span-4 3xl:col-span-4 flex flex-col gap-6 bg-white dark:bg-boxdark p-4 rounded-md">
+                <h2 className="text-xl font-medium">Rentabilidade x Desembolso</h2>
 
-            <div className="px-5 flex flex-col gap-5">
-              <div className="flex flex-col gap-3">
-                <div className="flex items-center justify-between">
-                  <span className="flex-1">Rentabilidade Anual</span>
-                  <CelerInputField
-                    ref={rentabilidadeSlideRef}
-                    name="rentabilidade_anual"
-                    fieldType={InputFieldVariant.INPUT}
-                    iconSrc={
-                      <CRMTooltip text="Insira um valor e pressione ENTER para modificar">
-                        <BiInfoCircle className="cursor-pointer" />
-                      </CRMTooltip>
-                    }
-                    defaultValue={`${(sliderValues.rentabilidade * 100).toFixed(2).replace(".", ",")}%`}
-                    className="w-25 text-right font-medium"
-                    onSubmit={(_, value) => handleChangeRentabilidadeSlider(value)}
-                    disabled={editLock}
-                  />
+                <div className="px-5 flex flex-col gap-5">
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-center justify-between">
+                      <span className="flex-1">Rentabilidade Anual</span>
+                      <CelerInputField
+                        ref={rentabilidadeSlideRef}
+                        name="rentabilidade_anual"
+                        fieldType={InputFieldVariant.INPUT}
+                        iconSrc={
+                          <CRMTooltip text="Insira um valor e pressione ENTER para modificar">
+                            <BiInfoCircle className="cursor-pointer" />
+                          </CRMTooltip>
+                        }
+                        defaultValue={`${(sliderValues.rentabilidade * 100).toFixed(2).replace(".", ",")}%`}
+                        className="w-25 text-right font-medium"
+                        onSubmit={(_, value) => handleChangeRentabilidadeSlider(value)}
+                        disabled={editLock}
+                      />
+                    </div>
+                    <input
+                      onChange={(e) => handleChangeRentabilidadeSlider(e.target.value, true)}
+                      type="range"
+                      min={0}
+                      max={2}
+                      step={0.01}
+                      className="w-full range-slider disabled:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                      value={sliderValues.rentabilidade}
+                    />
+                  </div>
                 </div>
-                <input
-                  onChange={(e) => handleChangeRentabilidadeSlider(e.target.value, true)}
-                  type="range"
-                  min={0}
-                  max={2}
-                  step={0.01}
-                  className="w-full range-slider disabled:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
-                  value={sliderValues.rentabilidade}
-                />
+
+                <div className="px-5 flex flex-col gap-5">
+                  <div className="flex flex-col gap-3">
+                    <div className="flex items-center justify-between">
+                      <span className="flex-1">Desembolso</span>
+                      <CelerInputField
+                        ref={desembolsoSlideRef}
+                        name="desembolso"
+                        fieldType={InputFieldVariant.INPUT}
+                        iconSrc={
+                          <CRMTooltip text="Insira um valor e pressione ENTER para modificar">
+                            <BiInfoCircle className="cursor-pointer" />
+                          </CRMTooltip>
+                        }
+                        defaultValue={numberFormat(sliderValues.desembolso) || "0,00"}
+                        className="max-w-40 text-right font-medium"
+                        onSubmit={(_, value) => handleChangeDesembolsoSlider(value)}
+                        disabled={editLock}
+                      />
+                    </div>
+                    <input
+                      onChange={(e) => handleChangeDesembolsoSlider(e.target.value, true)}
+                      type="range"
+                      min={data && handleDesembolsoVsRentabilidade(2, data).desembolso}
+                      max={data && data.properties["Valor Projetado"].number || 0}
+                      step={0.01}
+                      className="w-full range-slider disabled:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                      value={sliderValues.desembolso}
+                    />
+                  </div>
+                </div>
+
+                <Button
+                  disabled={disabledSaveButton}
+                  onClick={handleSaveValues}
+                  className="w-fit mx-auto text-sm uppercase">
+                  {loadingUpdateState === "formValues" && (<AiOutlineLoading className="animate-spin" />)}
+                  <span className="font-medium">Salvar Valores</span>
+                </Button>
+
+                {sliderError && (
+                  <span className="text-red-500 dark:text-red-400 text-xs uppercase font-medium text-center">Valores fora do escopo permitido!</span>
+                )}
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="col-span-1">
+                    <CelerInputField
+                      name="valor_projetado"
+                      fieldType={InputFieldVariant.INPUT}
+                      label="Valor Projetado"
+                      defaultValue={numberFormat(data?.properties["Valor Projetado"]?.number || 0)}
+                      className="w-full disabled:dark:text-white disabled:text-boxdark"
+                      disabled={true}
+                    />
+                  </div>
+                  <div className="col-span-1">
+                    <CelerInputField
+                      name="previsao_de_pgto"
+                      fieldType={InputFieldVariant.DATE}
+                      label="Previsão de pagamento"
+                      defaultValue={dateFormater(data?.properties["Previsão de pagamento"]?.date?.start)}
+                      className="w-full disabled:dark:text-white disabled:text-boxdark"
+                      onSubmit={(_, value) => handleUpdatePrevisaoDePagamento(value, id)}
+                    />
+                  </div>
+
+                  <hr className="border border-stroke dark:border-strokedark col-span-2" />
+
+                  <div className="col-span-2">
+                    <CelerInputField
+                      name="espelho_oficio_check"
+                      fieldType={InputFieldVariant.CHECKBOX}
+                      label="Espelho do Ofício"
+                      defaultValue={data?.properties["Espelho do ofício"].checkbox}
+                      checked={data?.properties["Espelho do ofício"].checkbox}
+                      className="text-sm font-medium"
+                      onValueChange={(_, value) => handleUpdateEspelhoDoOficio(value, id)}
+                      isLoading={loadingUpdateState === "Espelho do ofício"}
+                      disabled={editLock}
+                    />
+                  </div>
+
+                  {data?.properties["Esfera"].select?.name !== "FEDERAL" && (
+                    <div className="col-span-2">
+                      <CelerInputField
+                        name="espelho_oficio_check"
+                        fieldType={InputFieldVariant.CHECKBOX}
+                        label="Estoque de Precatórios Baixado"
+                        defaultValue={data?.properties["Estoque de Precatórios Baixado"].checkbox}
+                        checked={data?.properties["Estoque de Precatórios Baixado"].checkbox}
+                        className="text-sm font-medium"
+                        onValueChange={(_, value) => handleUpdateEstoquePrecatorio(value, id)}
+                        isLoading={loadingUpdateState === "Estoque de Precatórios Baixado"}
+                        disabled={editLock}
+                      />
+                    </div>
+                  )}
+
+                </div>
               </div>
             </div>
+          </section>
+        )}
 
-            <div className="px-5 flex flex-col gap-5">
-              <div className="flex flex-col gap-3">
-                <div className="flex items-center justify-between">
-                  <span className="flex-1">Desembolso</span>
-                  <CelerInputField
-                    ref={desembolsoSlideRef}
-                    name="desembolso"
-                    fieldType={InputFieldVariant.INPUT}
-                    iconSrc={
-                      <CRMTooltip text="Insira um valor e pressione ENTER para modificar">
-                        <BiInfoCircle className="cursor-pointer" />
-                      </CRMTooltip>
-                    }
-                    defaultValue={numberFormat(sliderValues.desembolso) || "0,00"}
-                    className="max-w-40 text-right font-medium"
-                    onSubmit={(_, value) => handleChangeDesembolsoSlider(value)}
-                    disabled={editLock}
-                  />
-                </div>
-                <input
-                  onChange={(e) => handleChangeDesembolsoSlider(e.target.value, true)}
-                  type="range"
-                  min={data && handleDesembolsoVsRentabilidade(2, data).desembolso}
-                  max={data && data.properties["Valor Projetado"].number || 0}
-                  step={0.01}
-                  className="w-full range-slider disabled:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
-                  value={sliderValues.desembolso}
-                />
-              </div>
-            </div>
-
-            <Button
-              disabled={disabledSaveButton}
-              onClick={handleSaveValues}
-              className="w-fit mx-auto text-sm uppercase">
-              {loadingUpdateState.formValores && (<AiOutlineLoading className="animate-spin" />)}
-              <span className="font-medium">Salvar Valores</span>
-            </Button>
-
-            {sliderError && (
-              <span className="text-red-500 dark:text-red-400 text-xs uppercase font-medium text-center">Valores fora do escopo permitido!</span>
-            )}
-
-            <div className="grid grid-cols-2 gap-3">
-              <div className="col-span-1">
-                <CelerInputField
-                  name="valor_projetado"
-                  fieldType={InputFieldVariant.INPUT}
-                  label="Valor Projetado"
-                  defaultValue={numberFormat(data?.properties["Valor Projetado"]?.number || 0)}
-                  className="w-full disabled:dark:text-white disabled:text-boxdark"
-                  disabled={true}
-                />
-              </div>
-              <div className="col-span-1">
-                <CelerInputField
-                  name="previsao_de_pgto"
-                  fieldType={InputFieldVariant.DATE}
-                  label="Previsão de pagamento"
-                  defaultValue={dateFormater(data?.properties["Previsão de pagamento"]?.date?.start)}
-                  className="w-full disabled:dark:text-white disabled:text-boxdark"
-                  onSubmit={(_, value) => handleUpdatePrevisaoDePagamento(value, id)}
-                />
-              </div>
-
-              <hr className="border border-stroke dark:border-strokedark col-span-2" />
-
-              <div className="col-span-2">
-                <CelerInputField
-                  name="espelho_oficio_check"
-                  fieldType={InputFieldVariant.CHECKBOX}
-                  label="Espelho do Ofício"
-                  defaultValue={data?.properties["Espelho do ofício"].checkbox}
-                  checked={data?.properties["Espelho do ofício"].checkbox}
-                  className="text-sm font-medium"
-                  onValueChange={(_, value) => handleUpdateEspelhoDoOficio(value, id)}
-                  isLoading={loadingUpdateState.espelhoOficio}
-                  disabled={editLock}
-                />
-              </div>
-
-              {data?.properties["Esfera"].select?.name !== "FEDERAL" && (
-                <div className="col-span-2">
-                  <CelerInputField
-                    name="espelho_oficio_check"
-                    fieldType={InputFieldVariant.CHECKBOX}
-                    label="Estoque de Precatórios Baixado"
-                    defaultValue={data?.properties["Estoque de Precatórios Baixado"].checkbox}
-                    checked={data?.properties["Estoque de Precatórios Baixado"].checkbox}
-                    className="text-sm font-medium"
-                    onValueChange={(_, value) => handleUpdateEstoquePrecatorio(value, id)}
-                    isLoading={loadingUpdateState.estoquePrecatorio}
-                    disabled={editLock}
-                  />
-                </div>
-              )}
-
-            </div>
-          </div>
-        </div>
-      </section>
 
       <section id="observacao" className="form-inputs-container">
         <div className="col-span-5">
@@ -2966,6 +3461,131 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
           </div>
         </div>
       </section>
+
+      {statusDiligence === "Revisão Valor/LOA" && (
+        <div className="flex items-center 2xsm:flex-col md:flex-row justify-center gap-6 bg-white dark:bg-boxdark p-4 rounded-md">
+          <Button
+            variant="info"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handleRepactuacao()}
+          >
+            <CgArrowsH className="h-4 w-4" />
+            <span>Repactuação</span>
+          </Button>
+
+          <Button
+            variant="warning"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handlePendencia()}
+          >
+            <BiX className="h-4 w-4" />
+            <span>Pendência a Sanar</span>
+          </Button>
+
+          <Button
+            variant="danger"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handleArchiving()}
+          >
+            <MdOutlineArchive className="h-4 w-4" />
+            <span>Arquivar</span>
+          </Button>
+
+          <Button
+            variant="success"
+            disabled={!data?.properties["Memória de Cálculo"].checkbox || !data?.properties["Preenchimento Correto"].checkbox} className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium disabled:opacity-50 disabled:pointer-events-none"
+            onClick={() => handleUpdateDuePhase("Pré-Due Ativo")}
+          >
+            <TiArrowForward className="h-4 w-4" />
+            <span>Seguir para Pré-Due Ativo</span>
+          </Button>
+        </div>
+      )}
+
+      {statusDiligence === "Pré-Due Ativo" && (
+        <div className="flex items-center 2xsm:flex-col md:flex-row justify-center gap-6 bg-white dark:bg-boxdark p-4 rounded-md">
+          <Button
+            variant="info"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handleRepactuacao()}
+          >
+            <CgArrowsH className="h-4 w-4" />
+            <span>Repactuação</span>
+          </Button>
+
+          <Button
+            variant="warning"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handleUpdateDuePhase("Revisão Valor/LOA")}
+          >
+            <TiArrowBack className="h-4 w-4" />
+            <span>Voltar para Revisão de Preço e Tempo</span>
+          </Button>
+
+          <Button
+            variant="danger"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handleArchiving()}
+          >
+            <MdOutlineArchive className="h-4 w-4" />
+            <span>Arquivar</span>
+          </Button>
+
+          <Button
+            variant="success"
+            disabled={!data?.properties["Autos do Ativo Judicial Baixado"].checkbox || !data?.properties["Há algum recurso?"].select?.name} className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium disabled:opacity-50 disabled:pointer-events-none"
+            onClick={() => handleUpdateDuePhase("Pré-Due Cedente")}
+          >
+            <TiArrowForward className="h-4 w-4" />
+            <span>Seguir para Pré-Due Cedente</span>
+          </Button>
+        </div>
+      )}
+
+      {statusDiligence === "Pré-Due Cedente" && (
+        <div className="flex items-center 2xsm:flex-col md:flex-row justify-center gap-6 bg-white dark:bg-boxdark p-4 rounded-md">
+          <Button
+            variant="info"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handleRepactuacao()}
+          >
+            <CgArrowsH className="h-4 w-4" />
+            <span>Repactuação</span>
+          </Button>
+
+          <Button
+            variant="warning"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handleUpdateDuePhase("Pré-Due Ativo")}
+          >
+            <TiArrowBack className="h-4 w-4" />
+            <span>Voltar para Pré-Due do Ativo</span>
+          </Button>
+
+          <Button
+            variant="danger"
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
+            onClick={() => handleArchiving()}
+          >
+            <MdOutlineArchive className="h-4 w-4" />
+            <span>Arquivar</span>
+          </Button>
+
+          <Button
+            variant="success"
+            disabled={
+              data?.properties["Esfera"].select?.name === "FEDERAL"
+              ? !data?.properties["Certidão Receita Federal/PGFN"].checkbox || !data?.properties["Relatório Resumido Processual"].checkbox
+              : !data?.properties["Certidão Receita Federal/PGFN"].checkbox || !data?.properties["Relatório Resumido Processual"].checkbox || !data?.properties["Certidão do Ente Devedor"].checkbox
+            }
+            className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium disabled:opacity-50 disabled:pointer-events-none"
+            onClick={() => handleUpdateDuePhase("Due Diligence")}
+          >
+            <TiArrowForward className="h-4 w-4" />
+            <span>Seguir para Due Diligence</span>
+          </Button>
+        </div>
+      )}
 
       {statusDiligence === "Repactuação" && (
         <div className="flex items-center 2xsm:flex-col md:flex-row justify-center gap-6 bg-white dark:bg-boxdark p-4 rounded-md">
@@ -3150,7 +3770,7 @@ ${(data?.properties["Observação"]?.rich_text?.[0]?.text?.content ?? "")}
             className="py-2 px-4 rounded-md 2xsm:w-full md:w-fit flex items-center gap-3 uppercase text-sm font-medium"
             onClick={() => handleReturnDueRevision()}
           >
-            {loadingUpdateState.returnDue ? <AiOutlineLoading className="animate-spin h-4 w-4" /> : <TbStatusChange className="h-4 w-4" />}
+            {loadingUpdateState === "Revisão de Due Diligence" ? <AiOutlineLoading className="animate-spin h-4 w-4" /> : <TbStatusChange className="h-4 w-4" />}
             <span>Retornar para revisão de Due</span>
           </Button>
 

--- a/src/components/LifeCycleStep/index.tsx
+++ b/src/components/LifeCycleStep/index.tsx
@@ -28,7 +28,10 @@ const steps = [
         alias: "Due",
         subLabels: [
             "Due em Andamento",
-            "Revisão de Due Diligence"
+            "Revisão de Due Diligence",
+            "Revisão Valor/LOA",
+            "Pré-Due Ativo",
+            "Pré-Due Cedente"
         ],
         icon: <MdOutlineContentPasteSearch className="text-2xl" />
     },


### PR DESCRIPTION
# Resumo da feat

- Foram inseridas 3 novas sections na visualização de detalhes do precatório. Elas são renderizadas separadamente de acordo com condicionais:

> Quando o status de diligência for Revisão Valor/LOA
> Quando o status de diligência for Pré-Due Ativo
> Quando o status de diligência for Pré-Due Cedente

 - Novos botões de ação foram adicionados também condicionalmente, dependendo de um dos status de diligência citados acima

- Adicionadas novas Tabs no filtro do jurídico

- Adicionadas mais sublabels ao componente LifeCycleStep

---

### Outras modificações

- Removido console do data no dashbroker card.

- Adicionado um setValue() referente a selic no componente de edição do card broker