### PR TITLE
✨ Input com máscara de CPF e CNPJ

### DIFF
--- a/src/components/CrmUi/CPFAndCNPFInput/index.tsx
+++ b/src/components/CrmUi/CPFAndCNPFInput/index.tsx
@@ -1,0 +1,19 @@
+import { Input } from '@/components/ui/input';
+import { CPFAndCNPJMask } from '@/functions/formaters/CPFAndCNPJInput';
+
+interface CPFAndCNPJInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    value: string;
+    setValue: (value: string) => void;
+}
+
+export function CPFAndCNPJInput({ value, setValue, ...props }: CPFAndCNPJInputProps) {
+    function handleChangeMask(event: React.ChangeEvent<HTMLInputElement>) {
+        const { value } = event.target;
+
+        setValue(CPFAndCNPJMask(value));
+    }
+
+    return (
+        <Input onChange={handleChangeMask} value={value} placeholder={'CPF ou CNPJ'} {...props} />
+    );
+}

--- a/src/functions/formaters/CPFAndCNPJInput.ts
+++ b/src/functions/formaters/CPFAndCNPJInput.ts
@@ -1,0 +1,17 @@
+export function CPFAndCNPJMask(v: string): string {
+    v = v.replace(/\D/g, '');
+
+    if (v.length <= 11) {
+        v = v.replace(/(\d{3})(\d)/, '$1.$2');
+        v = v.replace(/(\d{3})(\d)/, '$1.$2');
+        v = v.replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+    } else {
+        v = v.substring(0, 14);
+        v = v.replace(/^(\d{2})(\d)/, '$1.$2');
+        v = v.replace(/^(\d{2})\.(\d{3})(\d)/, '$1.$2.$3');
+        v = v.replace(/\.(\d{3})(\d)/, '.$1/$2');
+        v = v.replace(/(\d{4})(\d)/, '$1-$2');
+    }
+
+    return v;
+}


### PR DESCRIPTION
## Descrição
Cria o componente `CPFAndCNPJInput` que utiliza a função CPFAndCNPJMask para formatar o valor de acordo com o tamanho da string

O componente vai receber um estado e seu setter e poderá receber props nativas do input

## Exemplo
```ts
import { CPFAndCNPJInput } from '@/components/CrmUi/CPFAndCNPFInput';

export function Component() {
  const [inputValue, setInputValue] = useState('');

  return (
    <CPFAndCNPJInput value={inputValue} setValue={setInputValue} />
  )
}
```