### PR TITLE
Adds new entities to estadoRegimeEnteDevedor

### DIFF
--- a/src/constants/estado-regime-enteDevedor.ts
+++ b/src/constants/estado-regime-enteDevedor.ts
@@ -3444,6 +3444,9 @@ export const estadoRegimeEnteDevedor: IEstadoRegimeEnteDevedor = {
             'PETROLINA',
             'PRIMAVERA',
             'TRACUNHAÉM',
+            'FUNAPE - Fundação de Aposentadorias e Pensões do Estado de Pernambuco',
+            'FUNAFIN - Fundo Financeiro de Aposentadorias e Pensões dos Servidores do Estado de Pernambuco',
+            'INSTITUTO DE RECURSOS HUMANOS DE PERNAMBUCO IRH PE',
         ],
     },
     PI: {


### PR DESCRIPTION
Includes FUNAPE, FUNAFIN, and IRH PE to the list of entities for Pernambuco state