### PR TITLE
:sparkles: Feat: Ajustes nos formulários de cálculo

### DIFF
--- a/src/components/CrmUi/CPFAndCNPFInput/index.tsx
+++ b/src/components/CrmUi/CPFAndCNPFInput/index.tsx
@@ -1,22 +1,24 @@
 import { Input } from '@/components/ui/input';
 import { CPFAndCNPJMask } from '@/functions/formaters/CPFAndCNPJInput';
+import { CvldFormInputsProps } from '@/types/cvldform';
+import { UseFormSetValue } from 'react-hook-form';
 
 interface CPFAndCNPJInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     value: string;
-    setValue: (value: string) => void;
+    setValue: UseFormSetValue<Partial<CvldFormInputsProps>>;
 }
 
 export function CPFAndCNPJInput({ value, setValue, ...props }: CPFAndCNPJInputProps) {
     function handleChangeMask(event: React.ChangeEvent<HTMLInputElement>) {
         const { value } = event.target;
 
-        setValue(CPFAndCNPJMask(value));
+        setValue("cpf_cnpj", CPFAndCNPJMask(value));
     }
 
     return (
         <Input
-            onChange={handleChangeMask}
             value={value}
+            onChange={handleChangeMask}
             placeholder={'CPF ou CNPJ'}
             {...props}
             className={`focus-visible:ring-1 focus-visible:ring-blue-600 focus-visible:ring-offset-0 ${props.className}`}

--- a/src/components/CrmUi/Combobox/index.tsx
+++ b/src/components/CrmUi/Combobox/index.tsx
@@ -63,14 +63,15 @@ const CelerAppCombobox = <T extends FieldValues>({
                                         key={
                                             typeof item === 'string'
                                                 ? item
-                                                : item[Object.keys(item)[0]]
+                                                : item[Object.keys(item)[1]]
                                         }
                                         value={
                                             typeof item === 'string'
                                                 ? item
-                                                : String(item[Object.keys(item)[0]])
+                                                : String(item[Object.keys(item)[1]])
                                         }
                                         onSelect={(currentValue) => {
+
                                             onChangeValue!(
                                                 currentValue === value ? '' : currentValue,
                                             );
@@ -83,7 +84,7 @@ const CelerAppCombobox = <T extends FieldValues>({
                                                     ? item
                                                     : String(item[Object.keys(item)[0]])
                                             }
-                                            className={` ${className} truncate uppercase`}
+                                            className={`truncate uppercase`}
                                         >
                                             {typeof item === 'string'
                                                 ? item.toUpperCase()

--- a/src/components/Forms/CalcForm.tsx
+++ b/src/components/Forms/CalcForm.tsx
@@ -27,8 +27,6 @@ interface ICalcFormProps {
     hasDropzone?: boolean;
     isLoading?: boolean;
     formMode?: 'create' | 'update';
-    CPFOrCNPJValue: string;
-    setCPFOrCNPJValue: React.Dispatch<React.SetStateAction<string>>;
 }
 
 const CalcForm = ({
@@ -39,8 +37,6 @@ const CalcForm = ({
     hasDropzone = true,
     isLoading = false,
     formMode = 'create',
-    CPFOrCNPJValue,
-    setCPFOrCNPJValue,
 }: ICalcFormProps) => {
     // hook form imports
     const {
@@ -157,10 +153,6 @@ const CalcForm = ({
             setValue('status', data.properties['Status'].status?.name || '');
             setValue('upload_notion', true);
 
-            if (data.properties['CPF/CNPJ'].rich_text?.[0]?.text.content) {
-                setCPFOrCNPJValue(data.properties['CPF/CNPJ'].rich_text?.[0]?.text.content);
-            }
-
             // update auxDataSetter if exists
             auxDataSetter && auxDataSetter(watch());
         }
@@ -230,9 +222,6 @@ const CalcForm = ({
             setValue('esfera', oficioForm.result[0].esfera);
             setValue('ente_devedor', oficioForm.result[0].ente_devedor);
 
-            if (oficioForm.result[0].cpf_cnpj) {
-                setCPFOrCNPJValue(oficioForm.result[0].cpf_cnpj);
-            }
             setValue('regime', oficioForm.result[0].regime);
         }
     }, [oficioForm]);
@@ -319,9 +308,10 @@ const CalcForm = ({
 
                         <CelerAppCombobox
                             list={tribunais}
-                            onChangeValue={(value) =>
-                                setValue('tribunal', value)
-                            }
+                            onChangeValue={(value) => {
+                                const tribunal = tribunais.filter((tribunal) => tribunal.nome === value)[0]
+                                setValue('tribunal', tribunal.id)
+                            }}
                             value={
                                 tribunais.filter(
                                     (estado) =>
@@ -331,8 +321,8 @@ const CalcForm = ({
                             }
                             register={register('tribunal')}
                             name="tribunal"
-                            placeholder="BUSQUE POR ESTADO"
-                            className='h-[37px]'
+                            placeholder="BUSQUE POR TRIBUNAL"
+                            className='h-[37px] uppercase text-sm'
                         />
 
                         {/* <select
@@ -475,6 +465,8 @@ const CalcForm = ({
                         />
                     </div>
 
+                    <div className='col-span-1 hidden sm:block' />
+
                     <div className="flex flex-col gap-2 2xsm:col-span-2 sm:col-span-1">
                         <div className="relative flex flex-col justify-between">
                             <label
@@ -528,7 +520,91 @@ const CalcForm = ({
                         <div className="col-span-1 hidden sm:block"></div>
                     )}
 
-                    <div className="col-span-1 hidden sm:block" />
+                    {watch('esfera') && watch('esfera') !== 'FEDERAL' && (
+                        <div className="flex w-full flex-col gap-2 2xsm:col-span-2 sm:col-span-1">
+                            <label
+                                htmlFor="estado_ente_devedor"
+                                className="font-nexa text-xs font-semibold uppercase text-meta-5"
+                            >
+                                Estado do Ente Devedor
+                            </label>
+
+                            <CelerAppCombobox
+                                list={estados}
+                                onChangeValue={(value) => {
+                                    const estado = estados.filter(estado => estado.nome === value)[0];
+                                    setValue('estado_ente_devedor', estado.id)
+                                }}
+                                value={
+                                    estados.filter(
+                                        (estado) =>
+                                            estado.id ===
+                                            watch('estado_ente_devedor'),
+                                    )[0]?.nome || ''
+                                }
+                                register={register('estado_ente_devedor')}
+                                name="estado_ente_devedor"
+                                placeholder="BUSQUE POR ESTADO"
+                                className='uppercase text-sm'
+                            />
+
+                            {/* <select
+                                                        defaultValue={""}
+                                                        className="flex h-[37px] w-full cursor-pointer items-center justify-between rounded-md border border-stroke bg-background px-2 py-2 font-satoshi text-xs font-semibold uppercase ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:border-strokedark dark:bg-boxdark-2 [&>span]:line-clamp-1"
+                                                        {...register("estado_ente_devedor")}
+                                                    >
+                                                        {estados.map((estado) => (
+                                                            <option key={estado.id} value={estado.id}>
+                                                                {estado.nome}
+                                                            </option>
+                                                        ))}
+                                                    </select> */}
+                        </div>
+                    )}
+
+                    <div className="relative flex w-full flex-col gap-2 2xsm:col-span-2 sm:col-span-1">
+                        <label
+                            htmlFor="ente_devedor"
+                            className="font-nexa text-xs font-semibold uppercase text-meta-5"
+                        >
+                            Ente Devedor
+                        </label>
+                        {/* <input
+                                                type="text"
+                                                id="ente_devedor"
+                                                className="h-[37px] w-full rounded-md border border-stroke bg-white px-3 py-2 text-sm font-medium dark:border-strokedark dark:bg-boxdark-2"
+                                                {...register('ente_devedor', {})}
+                                            /> */}
+
+                        <CelerAppCombobox
+                            list={opcoesEntesDevedores}
+                            onChangeValue={(value) =>
+                                setValue('ente_devedor', value)
+                            }
+                            value={
+                                opcoesEntesDevedores.filter(
+                                    (estado) =>
+                                        estado === watch('ente_devedor'),
+                                )[0] || ''
+                            }
+                            register={register('ente_devedor', {
+                                required: {
+                                    value: true,
+                                    message: 'Esse campo é obrigatório',
+                                }
+                            })}
+                            name="ente_devedor"
+                            placeholder="BUSQUE PELO ENTE DEVEDOR"
+                            className={`${errors.ente_devedor && "!border-red"} uppercase text-sm`}
+                        />
+                        {errors.ente_devedor && (
+                            <span className="absolute right-8.5 top-8.5 text-xs font-medium text-red">
+                                campo obrigatório
+                            </span>
+                        )}
+                    </div>
+
+                    {watch('esfera') && watch('esfera') === 'FEDERAL' && <div className='col-span-1 hidden sm:block'/>}
 
                     <div className={`col-span-2 flex max-h-6 items-center gap-2 md:col-span-1`}>
                         <CustomCheckbox
@@ -918,10 +994,22 @@ const CalcForm = ({
                                                 CPF/CNPJ
                                             </label>
                                             <CPFAndCNPJInput
-                                                value={CPFOrCNPJValue}
-                                                setValue={setCPFOrCNPJValue}
-                                                className={`${CPFOrCNPJValue && !isCPFOrCNPJValid(CPFOrCNPJValue) && 'focus-visible:ring-meta-1'} h-9.5 w-full rounded-md border border-stroke bg-white px-3 py-2 text-sm font-medium dark:border-strokedark dark:bg-boxdark-2`}
+                                                value={watch("cpf_cnpj") || ""}
+                                                setValue={setValue}
+                                                className={`h-9.5 w-full rounded-md border border-stroke bg-white px-3 py-2 text-sm font-medium dark:border-strokedark dark:bg-boxdark-2`}
                                             />
+                                            {/* <Controller
+                                                name='cpf_cnpj'
+                                                control={control}
+                                                render={({ field }) => (
+                                                    <CPFAndCNPJInput
+                                                        {...field}
+                                                        value={watch("cpf_cnpj") || ""}
+                                                        setValue={setValue}
+                                                    // className={`${CPFOrCNPJValue && !isCPFOrCNPJValid(CPFOrCNPJValue) && 'focus-visible:ring-meta-1'} h-9.5 w-full rounded-md border border-stroke bg-white px-3 py-2 text-sm font-medium dark:border-strokedark dark:bg-boxdark-2`}
+                                                    />
+                                                )}
+                                            /> */}
                                         </div>
 
                                         <div className=" flex w-full flex-row justify-between gap-4 2xsm:col-span-2 sm:col-span-1">
@@ -1003,86 +1091,6 @@ const CalcForm = ({
                                                     />
                                                 )}
                                             />
-                                        </div>
-
-                                        {watch('esfera') && watch('esfera') !== 'FEDERAL' && (
-                                            <div className="flex w-full flex-col gap-2 2xsm:col-span-2 sm:col-span-1">
-                                                <label
-                                                    htmlFor="estado_ente_devedor"
-                                                    className="font-nexa text-xs font-semibold uppercase text-meta-5"
-                                                >
-                                                    Estado do Ente Devedor
-                                                </label>
-
-                                                <CelerAppCombobox
-                                                    list={estados}
-                                                    onChangeValue={(value) =>
-                                                        setValue('estado_ente_devedor', value)
-                                                    }
-                                                    value={
-                                                        estados.filter(
-                                                            (estado) =>
-                                                                estado.id ===
-                                                                watch('estado_ente_devedor'),
-                                                        )[0]?.nome || ''
-                                                    }
-                                                    register={register('estado_ente_devedor')}
-                                                    name="estado_ente_devedor"
-                                                    placeholder="BUSQUE POR ESTADO"
-                                                />
-
-                                                {/* <select
-                                                        defaultValue={""}
-                                                        className="flex h-[37px] w-full cursor-pointer items-center justify-between rounded-md border border-stroke bg-background px-2 py-2 font-satoshi text-xs font-semibold uppercase ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50 dark:border-strokedark dark:bg-boxdark-2 [&>span]:line-clamp-1"
-                                                        {...register("estado_ente_devedor")}
-                                                    >
-                                                        {estados.map((estado) => (
-                                                            <option key={estado.id} value={estado.id}>
-                                                                {estado.nome}
-                                                            </option>
-                                                        ))}
-                                                    </select> */}
-                                            </div>
-                                        )}
-                                        <div className="relative flex w-full flex-col gap-2 2xsm:col-span-2 sm:col-span-1">
-                                            <label
-                                                htmlFor="ente_devedor"
-                                                className="font-nexa text-xs font-semibold uppercase text-meta-5"
-                                            >
-                                                Ente Devedor
-                                            </label>
-                                            {/* <input
-                                                type="text"
-                                                id="ente_devedor"
-                                                className="h-[37px] w-full rounded-md border border-stroke bg-white px-3 py-2 text-sm font-medium dark:border-strokedark dark:bg-boxdark-2"
-                                                {...register('ente_devedor', {})}
-                                            /> */}
-
-                                            <CelerAppCombobox
-                                                list={opcoesEntesDevedores}
-                                                onChangeValue={(value) =>
-                                                    setValue('ente_devedor', value)
-                                                }
-                                                value={
-                                                    opcoesEntesDevedores.filter(
-                                                        (estado) =>
-                                                            estado === watch('ente_devedor'),
-                                                    )[0] || ''
-                                                }
-                                                register={register('ente_devedor', {
-                                                    required: {
-                                                        value: true,
-                                                        message: 'Esse campo é obrigatório',
-                                                    }
-                                                })}
-                                                name="ente_devedor"
-                                                placeholder="BUSQUE PELO ENTE DEVEDOR"
-                                            />
-                                            {errors.ente_devedor && (
-                                                <span className="absolute right-8.5 top-8.5 text-xs font-medium text-red">
-                                                    campo obrigatório
-                                                </span>
-                                            )}
                                         </div>
 
                                         <div className="flex w-full flex-col gap-2 2xsm:col-span-2 sm:col-span-1">

--- a/src/components/Forms/EditOficioBrokerForm.tsx
+++ b/src/components/Forms/EditOficioBrokerForm.tsx
@@ -31,7 +31,6 @@ const EditOficioBrokerForm = ({ mainData }: IFormBroker): React.JSX.Element => {
 
     /* ====> dados inicias do formulário */
     const [defaultFormValues, setDefaultFormValues] = useState<any>(null);
-    const [CPFOrCNPJValue, setCPFOrCNPJValue] = useState<string>('');
 
     /* ====> form imports <==== */
     const form = useForm<Partial<CvldFormInputsProps>>();
@@ -100,17 +99,19 @@ const EditOficioBrokerForm = ({ mainData }: IFormBroker): React.JSX.Element => {
             data.need_to_recalculate_proposal = false;
         }
 
-        if (!isCPFOrCNPJValid(CPFOrCNPJValue)) {
-            MySwal.fire({
-                title: 'Ok, Houston...Temos um problema!',
-                text: 'O CPF ou CNPJ inserido é inválido. Por favor, tente novamente.',
-                icon: 'error',
-                showConfirmButton: true,
-            });
-            return;
-        }
+        if (data.gerar_cvld) {
+            if (!isCPFOrCNPJValid(form.watch('cpf_cnpj') || "")) {
+                MySwal.fire({
+                    title: 'Ok, Houston...Temos um problema!',
+                    text: 'O CPF ou CNPJ inserido é inválido. Por favor, tente novamente.',
+                    icon: 'error',
+                    showConfirmButton: true,
+                });
+                return;
+            }
 
-        data.cpf_cnpj = CPFOrCNPJValue;
+            data.cpf_cnpj = form.watch("cpf_cnpj");
+        }
 
         if (data.valor_aquisicao_total) {
             data.percentual_a_ser_adquirido = 1;
@@ -188,8 +189,6 @@ const EditOficioBrokerForm = ({ mainData }: IFormBroker): React.JSX.Element => {
                     formMode="update"
                     isLoading={isSavingEdit}
                     auxDataSetter={setDefaultFormValues}
-                    CPFOrCNPJValue={CPFOrCNPJValue}
-                    setCPFOrCNPJValue={setCPFOrCNPJValue}
                 />
             </div>
         </div>

--- a/src/components/MainForm/index.tsx
+++ b/src/components/MainForm/index.tsx
@@ -46,7 +46,6 @@ const MainForm: React.FC<CVLDFormProps> = ({ dataCallback, setCalcStep, setDataT
 
     const mySwal = UseMySwal();
     const [loading, setLoading] = useState<boolean>(false);
-    const [CPFOrCNPJValue, setCPFOrCNPJValue] = useState<string>('');
 
     const [state, setState] = useState<ChartTwoState>({
         series: [
@@ -101,17 +100,19 @@ const MainForm: React.FC<CVLDFormProps> = ({ dataCallback, setCalcStep, setDataT
             data.data_limite_de_atualizacao = formattedDate;
         }
 
-        if (!isCPFOrCNPJValid(CPFOrCNPJValue)) {
-            MySwal.fire({
-                title: 'Ok, Houston...Temos um problema!',
-                text: 'O CPF ou CNPJ inserido é inválido. Por favor, tente novamente.',
-                icon: 'error',
-                showConfirmButton: true,
-            });
-            return;
-        }
+        if (data.gerar_cvld) {
+            if (!isCPFOrCNPJValid(form.watch('cpf_cnpj') || "")) {
+                MySwal.fire({
+                    title: 'Ok, Houston...Temos um problema!',
+                    text: 'O CPF ou CNPJ inserido é inválido. Por favor, tente novamente.',
+                    icon: 'error',
+                    showConfirmButton: true,
+                });
+                return;
+            }
 
-        data.cpf_cnpj = CPFOrCNPJValue;
+            data.cpf_cnpj = form.watch("cpf_cnpj");
+        }
 
         if (!data.status) {
             data.status = 'Realizar Primeiro Contato';
@@ -370,8 +371,6 @@ const MainForm: React.FC<CVLDFormProps> = ({ dataCallback, setCalcStep, setDataT
                 onSubmitForm={onSubmit}
                 formConfigs={form}
                 isLoading={loading}
-                CPFOrCNPJValue={CPFOrCNPJValue}
-                setCPFOrCNPJValue={setCPFOrCNPJValue}
             />
         </div>
     );

--- a/src/components/Modals/NewForm.tsx
+++ b/src/components/Modals/NewForm.tsx
@@ -23,12 +23,13 @@ import { GiResize } from 'react-icons/gi';
 import CalcForm from '../Forms/CalcForm';
 import { isCPFOrCNPJValid } from '@/functions/verifiers/isCPFOrCNPJValid';
 import UseMySwal from '@/hooks/useMySwal';
+import { regimeEspecialExceptions } from '@/constants/excecoes-regime-especial';
 
 const NewForm = () => {
     const { setSaveInfoToNotion, usersList } = useContext(TableNotionContext);
     const MySwal = UseMySwal();
 
-    const [CPFOrCNPJValue, setCPFOrCNPJValue] = useState<string>('');
+    // const [CPFOrCNPJValue, setCPFOrCNPJValue] = useState<string>('');
     const [auxValues, setAuxValues] = useState<{ proposal: number; commission: number }>({
         proposal: 0,
         commission: 0,
@@ -64,7 +65,7 @@ const NewForm = () => {
         defaultValues: {
             numero_de_meses: 0,
             gerar_cvld: true,
-        },
+        }
     });
 
     // Função para atualizar a proposta e ajustar a comissão proporcionalmente
@@ -287,7 +288,7 @@ const NewForm = () => {
         }
 
         if (data.gerar_cvld) {
-            if (!isCPFOrCNPJValid(CPFOrCNPJValue)) {
+            if (!isCPFOrCNPJValid(form.watch('cpf_cnpj') || "")) {
                 MySwal.fire({
                     title: 'Ok, Houston...Temos um problema!',
                     text: 'O CPF ou CNPJ inserido é inválido. Por favor, tente novamente.',
@@ -297,7 +298,7 @@ const NewForm = () => {
                 return;
             }
 
-            data.cpf_cnpj = CPFOrCNPJValue;
+            data.cpf_cnpj = form.watch("cpf_cnpj");
         }
 
         try {
@@ -438,8 +439,6 @@ const NewForm = () => {
                                     onSubmitForm={onSubmit}
                                     formConfigs={form}
                                     hasDropzone={false}
-                                    CPFOrCNPJValue={CPFOrCNPJValue}
-                                    setCPFOrCNPJValue={setCPFOrCNPJValue}
                                 />
                             </div>
 
@@ -454,9 +453,9 @@ const NewForm = () => {
                                     <>
                                         {showResults ? (
                                             <div
-                                                className={`relative flex flex-col ${form.watch('regime') === 'ESPECIAL' ? 'pointer-events-none' : ''}`}
+                                                className={`relative flex flex-col ${form.watch('regime') === 'ESPECIAL' && !regimeEspecialExceptions.includes(form.watch("ente_devedor")!) ? 'pointer-events-none' : ''}`}
                                             >
-                                                {form.watch("regime") === "ESPECIAL" && (
+                                                {form.watch("regime") === "ESPECIAL" && !regimeEspecialExceptions.includes(form.watch("ente_devedor")!) && (
                                                         <div className="absolute flex min-h-full w-full flex-col items-center justify-center bg-slate-700/90">
                                                             <h2 className="text-md w-full p-4 text-center font-satoshi font-medium uppercase">
                                                                 Para ativos de regime{' '}

--- a/src/constants/excecoes-regime-especial.ts
+++ b/src/constants/excecoes-regime-especial.ts
@@ -1,0 +1,6 @@
+export const regimeEspecialExceptions = [
+    "ESTADO DE PERNAMBUCO",
+    "FUNAPE - Fundação de Aposentadorias e Pensões do Estado de Pernambuco",
+    "FUNAFIN - Fundo Financeiro de Aposentadorias e Pensões dos Servidores do Estado de Pernambuco",
+    "INSTITUTO DE RECURSOS HUMANOS DE PERNAMBUCO IRH PE"
+]


### PR DESCRIPTION
# Descrição

Os ajustes abaixo estão separados por componentes

**Legendas**:

> 🎉 Adição de nova funcionalidade
> 🔧 Ajustes no código
> ❌ Exclusão de código

### CelerAppCombobox

- 🔧 Key e Value do componente foram ajustados para quando o formato da lista for Record, o valor renderizado seja o nome, e o valor selecionado a sigla (ID)

---

### CPFAndCNPJInput

- 🔧 Tipagem do componente agora segue um padrão mais voltado ao react-hook-form

-  🔧Função de setValue() modificada para o padrão do react-hook-form

---

### CalcForm

- ❌ Props de antigo estado de CPF/CNPJ removidas.

- ❌ Condicionais de inserção de valores no campo CPF/CNPJ dentro dos useEffects removidos.

- 🔧 Funções de onChangeValue do `CelerAppCombobox` tiveram parte de sua lógica alteradas para encaixarem com a nova lógica já mencionada acima.

- 🔧 Campos de `Ente Devedor` e `Estado do Ente Devedor` movidos para área que não necessita do condicional `gerar_cvld`

- 🔧 Valores de entrada no `CPFAndCNPJInput` alterados para encaixarem na lógica já mencionada acima.

---

### EditOficioBrokerForm & MainForm

- ❌ Declaração de Estados referente a CPF/CNPJ removidos.

- 🔧 Lógica ao enviar submit para verificar CPF/CNPJ ajustada.

- ❌ Props de entrada do CalcForm removidas para se encaixar com nova lógica já mencionada acima.

---

### NewForm

O NewForm passou por modificações iguais aos outros, porém, por conta do slider de proposta, teve um ajuste considerável

- 🎉 Adicionada lógica de verificação de exceção de Ente Devedor em regime especial, para que a mensagem de revalidação de proposta/comissão não seja exibida.