### PR TITLE
:wrench: Fix: Problemas ao enviar porcentagem nos formulários

### DIFF
--- a/src/components/Forms/CalcForm.tsx
+++ b/src/components/Forms/CalcForm.tsx
@@ -119,7 +119,7 @@ const CalcForm = ({
             );
             setValue(
                 'percentual_a_ser_adquirido',
-                data.properties['Percentual a ser adquirido'].number! * 100,
+                (data.properties['Percentual a ser adquirido'].number! * 100).toFixed(2).replace(".", ","),
             );
             setValue(
                 'ja_possui_destacamento',
@@ -127,7 +127,7 @@ const CalcForm = ({
             );
             setValue(
                 'percentual_de_honorarios',
-                data.properties['Percentual de Honorários Não destacados'].number! * 100 || 0,
+                (data.properties['Percentual de Honorários Não destacados'].number! * 100 || 0).toFixed(2).replace(".", ","),
             );
             setValue(
                 'nao_incide_selic_no_periodo_db_ate_abril',
@@ -228,6 +228,10 @@ const CalcForm = ({
             setValue('regime', oficioForm.result[0].regime);
         }
     }, [oficioForm]);
+
+    if (data) {
+        console.log(data.properties["Credor"].title[0]?.text.content === "LUIZ INALDO - TESTE PERCENTUAIS" ? data : null);
+    }
 
     return (
         <React.Fragment>
@@ -716,12 +720,37 @@ const CalcForm = ({
                                     >
                                         Percentual
                                     </label>
-                                    <input
-                                        type="number"
-                                        id="percentual_de_honorarios"
+                                    <Controller
+                                        name="percentual_de_honorarios"
+                                        control={control}
                                         defaultValue={30}
-                                        className="h-[37px] w-full rounded-md border border-stroke bg-white px-3 py-2 text-sm font-medium dark:border-strokedark dark:bg-boxdark-2"
-                                        {...register('percentual_de_honorarios', {})}
+                                        rules={{
+                                            min: {
+                                                value: 1,
+                                                message: 'O valor deve ser maior que 0',
+                                            },
+                                        }}
+                                        render={({ field, fieldState: { error } }) => (
+                                            <>
+                                                <Cleave
+                                                    {...field}
+                                                    className={`w-full rounded-md border-stroke ${error ? 'border-red' : 'dark:border-strokedark'} px-3 py-2 text-sm font-medium dark:bg-boxdark-2 dark:text-bodydark`}
+                                                    options={{
+                                                        numeral: true,
+                                                        numeralThousandsGroupStyle: 'none',
+                                                        numeralDecimalMark: ',',
+                                                        prefix: '%',
+                                                        tailPrefix: true,
+                                                        rawValueTrimPrefix: true,
+                                                    }}
+                                                />
+                                                {error && (
+                                                    <span className="absolute right-2 top-8.5 text-xs font-medium text-red">
+                                                        {error.message}
+                                                    </span>
+                                                )}
+                                            </>
+                                        )}
                                     />
                                 </div>
                             </div>

--- a/src/components/Forms/EditOficioBrokerForm.tsx
+++ b/src/components/Forms/EditOficioBrokerForm.tsx
@@ -116,16 +116,14 @@ const EditOficioBrokerForm = ({ mainData }: IFormBroker): React.JSX.Element => {
         if (data.valor_aquisicao_total) {
             data.percentual_a_ser_adquirido = 1;
         } else {
-            if (typeof data.percentual_a_ser_adquirido === 'string') {
-                // data.percentual_a_ser_adquirido = Number((data.percentual_a_ser_adquirido.replace(/[^0-9,]/g, "").replace(",", ".") / 100).toFixed(4))
-                data.percentual_a_ser_adquirido =
-                    parseFloat(data.percentual_a_ser_adquirido.replace('%', '')) / 100;
-            } else {
-                data.percentual_a_ser_adquirido = data.percentual_a_ser_adquirido / 100;
-            }
+            data.percentual_a_ser_adquirido = Number(data.percentual_a_ser_adquirido.replace("%", "").replace(",", ".")) / 100;
         }
 
-        data.percentual_de_honorarios /= 100;
+        if (data.ja_possui_destacamento) {
+            data.percentual_de_honorarios = 0;
+        } else {
+            data.percentual_de_honorarios = Number(data.percentual_de_honorarios.replace("%", "").replace(",", ".")) / 100;
+        }
 
         if (typeof data.valor_principal === 'string') {
             data.valor_principal = backendNumberFormat(data.valor_principal) || 0;

--- a/src/components/Juridico/Details.tsx
+++ b/src/components/Juridico/Details.tsx
@@ -172,16 +172,18 @@ export const LegalDetails = ({ id }: JuridicoDetailsProps) => {
       formData.observacao = `
 💭 Comentários: ${formData.observacao}
 `
-    }
+    };
 
     if (formData.valor_aquisicao_total) {
       formData.percentual_a_ser_adquirido = 1;
     } else {
-      formData.percentual_a_ser_adquirido = formData.percentual_a_ser_adquirido / 100;
+      formData.percentual_a_ser_adquirido = Number(formData.percentual_a_ser_adquirido.replace(",", ".")) / 100;
     }
 
     if (!formData.ja_possui_destacamento) {
-      formData.percentual_de_honorarios = formData.percentual_de_honorarios / 100
+      formData.percentual_de_honorarios = Number(formData.percentual_de_honorarios.replace(",", ".")) / 100
+    } else {
+      formData.percentual_de_honorarios = 0
     }
 
     if (typeof formData.valor_principal === "string") {
@@ -227,7 +229,6 @@ export const LegalDetails = ({ id }: JuridicoDetailsProps) => {
 
     formData.upload_notion = true;
     formData.need_to_recalculate_proposal = true;
-
 
     swal.fire({
       title: 'Confirmação',

--- a/src/components/MainForm/index.tsx
+++ b/src/components/MainForm/index.tsx
@@ -85,7 +85,7 @@ const MainForm: React.FC<CVLDFormProps> = ({ dataCallback, setCalcStep, setDataT
         data.valor_juros = backendNumberFormat(data.valor_juros) || 0;
         data.outros_descontos = backendNumberFormat(data.outros_descontos) || 0;
         data.valor_pss = backendNumberFormat(data.valor_pss) || 0;
-        data.percentual_a_ser_adquirido /= 100;
+        
 
         //#TODO colocar essa condicional dentro de uma função utilitária
         if (!data.data_limite_de_atualizacao_check) {
@@ -161,13 +161,13 @@ const MainForm: React.FC<CVLDFormProps> = ({ dataCallback, setCalcStep, setDataT
         if (data.ja_possui_destacamento) {
             data.percentual_de_honorarios = 0;
         } else {
-            data.percentual_de_honorarios /= 100;
+            data.percentual_de_honorarios = Number(data.percentual_de_honorarios.replace("%", "").replace(",", ".")) / 100;
         }
 
         if (data.valor_aquisicao_total) {
             data.percentual_a_ser_adquirido = 1;
         } else {
-            data.percentual_a_ser_adquirido = data.percentual_a_ser_adquirido / 100;
+            data.percentual_a_ser_adquirido = Number(data.percentual_a_ser_adquirido.replace("%", "").replace(",", ".")) / 100;
         }
 
         if (!data.estado_ente_devedor) {

--- a/src/components/Modals/NewForm.tsx
+++ b/src/components/Modals/NewForm.tsx
@@ -242,11 +242,7 @@ const NewForm = () => {
         if (data.valor_aquisicao_total) {
             data.percentual_a_ser_adquirido = 1;
         } else {
-            data.percentual_a_ser_adquirido = data.percentual_a_ser_adquirido = Number(
-                (
-                    data.percentual_a_ser_adquirido.replace(/[^0-9,]/g, '').replace(',', '.') / 100
-                ).toFixed(4),
-            );
+            data.percentual_a_ser_adquirido = Number(data.percentual_a_ser_adquirido.replace("%", "").replace(",", ".")) / 100;
         }
 
         if (data.tribunal === 'TRF1' || data.tribunal === 'TRF6') {
@@ -264,7 +260,7 @@ const NewForm = () => {
         if (data.ja_possui_destacamento) {
             data.percentual_de_honorarios = 0;
         } else {
-            data.percentual_de_honorarios /= 100;
+            data.percentual_de_honorarios = Number(data.percentual_de_honorarios.replace("%", "").replace(",", ".")) / 100;
         }
 
         if (data.gerar_cvld) {

--- a/src/types/cvldform.ts
+++ b/src/types/cvldform.ts
@@ -13,7 +13,7 @@ export type CvldFormInputsProps = {
     valor_aquisicao_total: boolean;
     percentual_a_ser_adquirido: number | string;
     ja_possui_destacamento: boolean;
-    percentual_de_honorarios: number;
+    percentual_de_honorarios: number | string;
     incidencia_juros_moratorios:
     boolean;
     nao_incide_selic_no_periodo_db_ate_abril: boolean;


### PR DESCRIPTION
# Descrição

Um erro estava ocorrendo ao enviar os percentuais de `Aquisição do precatório` e `Honorários destacados`, pois o front não estava formatando dados com casas decimais.

Foi implementada em cada lógica de submit dos formulários um formatter para que os dados possam ir de acordo com o esperado.

---

## Outras mudanças

Outras mudanças ocorreram em conjunto com essa correção:

- Mudança do input `number` do `percentual de honorários` para um Controller com Cleave, seguindo padrão do `Percentual de aquisição`

- Mudança na tipagem do `CvldFormInputsProps`, onde o campo `percentual_de_honorarios` pode ser number ou string.