### PR TITLE
:sparkles: Feat: Bloqueio de proposta aceita mediante checks

### DIFF
--- a/src/components/Cards/DashbrokersCard.tsx
+++ b/src/components/Cards/DashbrokersCard.tsx
@@ -901,7 +901,7 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
         <div className="relative col-span-1 gap-5 rounded-md border border-stroke bg-white p-5 dark:border-strokedark dark:bg-boxdark">
             {/* ----> info <----- */}
             <div className="mb-2 flex items-center justify-between">
-                <div className="flex w-fit items-center justify-center gap-2">
+                <div className={`flex w-fit items-center justify-center gap-2 opacity-50 pointer-events-none ${(checks.are_docs_complete || checks.is_cedente_complete || checks.is_precatorio_complete) && "!opacity-100 !pointer-events-auto"}`}>
                     {isProposalChanging ? (
                         <AiOutlineLoading className="animate-spin" />
                     ) : (


### PR DESCRIPTION
# Descrição

O checkbox de `Proposta Aceita` estava habilitado mesmo quando todos os checks do precatório estavam em vermelho. Isso acabava gerando um erro na hora de salvar a proposta.

Foi colocada uma pequena lógica que esmaeçe o checkbox e impede o click caso todos os checks do precatório sejam vermelhos. Se algum for concluído (verde), o check é liberado, enviando o precatório para o estado de `Pendencia a Sanar`.