### PR TITLE
:wrench: Fix: Problema ao enviar tipo do ofício como "Creditório"

### DIFF
--- a/src/components/Forms/EditOficioBrokerForm.tsx
+++ b/src/components/Forms/EditOficioBrokerForm.tsx
@@ -13,6 +13,7 @@ import { verifyUpdateFields } from '@/functions/verifiers/verifyValues';
 import CalcForm from './CalcForm';
 import { isCPFOrCNPJValid } from '@/functions/verifiers/isCPFOrCNPJValid';
 import UseMySwal from '@/hooks/useMySwal';
+import { getCurrentFormattedDate } from '@/functions/getCurrentFormattedDate';
 
 interface IFormBroker {
     mainData: NotionPage | null;
@@ -93,10 +94,17 @@ const EditOficioBrokerForm = ({ mainData }: IFormBroker): React.JSX.Element => {
 
     // função para alterar os dados do oficio (submit)
     async function onSubmit(data: any) {
+
         if (verifyUpdateFields(defaultFormValues, data)) {
             data.need_to_recalculate_proposal = true;
         } else {
             data.need_to_recalculate_proposal = false;
+        }
+
+        if (data.tipo_do_oficio === 'CREDITÓRIO') {
+
+            const formattedDate = getCurrentFormattedDate().split('/').reverse().join('-');
+            data.data_requisicao = formattedDate;
         }
 
         if (data.gerar_cvld) {
@@ -157,8 +165,10 @@ const EditOficioBrokerForm = ({ mainData }: IFormBroker): React.JSX.Element => {
             data.valor_pss = 0;
         }
 
-        if (!data.data_limite_de_atualizacao_check && data.data_limite_de_atualizacao) {
-            delete data.data_limite_de_atualizacao;
+        if (!data.data_limite_de_atualizacao_check) {
+
+            const formattedDate = getCurrentFormattedDate().split('/').reverse().join('-');
+            data.data_limite_de_atualizacao = formattedDate;
         }
 
         await updateOficio.mutateAsync(data);

--- a/src/components/MainForm/index.tsx
+++ b/src/components/MainForm/index.tsx
@@ -15,6 +15,7 @@ import backendNumberFormat from '@/functions/formaters/backendNumberFormat';
 import { CvldFormInputsProps } from '@/types/cvldform';
 import CalcForm from '../Forms/CalcForm';
 import { isCPFOrCNPJValid } from '@/functions/verifiers/isCPFOrCNPJValid';
+import { getCurrentFormattedDate } from '@/functions/getCurrentFormattedDate';
 
 interface ChartTwoState {
     series: {
@@ -87,16 +88,15 @@ const MainForm: React.FC<CVLDFormProps> = ({ dataCallback, setCalcStep, setDataT
         data.valor_pss = backendNumberFormat(data.valor_pss) || 0;
         
 
-        //#TODO colocar essa condicional dentro de uma função utilitária
-        if (!data.data_limite_de_atualizacao_check) {
-            const dateInSaoPaulo = new Date().toLocaleDateString('pt-BR', {
-                timeZone: 'America/Sao_Paulo',
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-            });
+        if (data.tipo_do_oficio === 'CREDITÓRIO') {
 
-            const formattedDate = dateInSaoPaulo.split('/').reverse().join('-');
+            const formattedDate = getCurrentFormattedDate().split('/').reverse().join('-');
+            data.data_requisicao = formattedDate;
+        }
+
+        if (!data.data_limite_de_atualizacao_check) {
+
+            const formattedDate = getCurrentFormattedDate().split('/').reverse().join('-');
             data.data_limite_de_atualizacao = formattedDate;
         }
 

--- a/src/components/Modals/NewForm.tsx
+++ b/src/components/Modals/NewForm.tsx
@@ -24,6 +24,7 @@ import CalcForm from '../Forms/CalcForm';
 import { isCPFOrCNPJValid } from '@/functions/verifiers/isCPFOrCNPJValid';
 import UseMySwal from '@/hooks/useMySwal';
 import { regimeEspecialExceptions } from '@/constants/excecoes-regime-especial';
+import { getCurrentFormattedDate } from '@/functions/getCurrentFormattedDate';
 
 const NewForm = () => {
     const { setSaveInfoToNotion, usersList } = useContext(TableNotionContext);
@@ -228,14 +229,8 @@ const NewForm = () => {
         data.valor_pss = backendNumberFormat(data.valor_pss) || 0;
 
         if (data.tipo_do_oficio === 'CREDITÓRIO') {
-            const dateInSaoPaulo = new Date().toLocaleDateString('pt-BR', {
-                timeZone: 'America/Sao_Paulo',
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-            });
 
-            const formattedDate = dateInSaoPaulo.split('/').reverse().join('-');
+            const formattedDate = getCurrentFormattedDate().split('/').reverse().join('-');
             data.data_requisicao = formattedDate;
         }
 
@@ -276,14 +271,8 @@ const NewForm = () => {
         }
 
         if (!data.data_limite_de_atualizacao_check) {
-            const dateInSaoPaulo = new Date().toLocaleDateString('pt-BR', {
-                timeZone: 'America/Sao_Paulo',
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-            });
 
-            const formattedDate = dateInSaoPaulo.split('/').reverse().join('-');
+            const formattedDate = getCurrentFormattedDate().split('/').reverse().join('-');
             data.data_limite_de_atualizacao = formattedDate;
         }
 

--- a/src/functions/getCurrentFormattedDate.ts
+++ b/src/functions/getCurrentFormattedDate.ts
@@ -1,0 +1,15 @@
+/**
+ * Retorna a data atual no formato "dd/mm/yyyy" na timezone de São Paulo.
+ *
+ * @returns string - Data atual formatada no padr o brasileiro.
+ */
+export function getCurrentFormattedDate (): string {
+    const dateInSaoPaulo = new Date().toLocaleDateString('pt-BR', {
+        timeZone: 'America/Sao_Paulo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    });
+
+    return dateInSaoPaulo;
+}


### PR DESCRIPTION
# Descrição

🔧 No MainForm não existia condicional para setar a data de requisição como data atual quando o tipo do ofício fosse `"CREDITÓRIO"`.

:tada: Foi adicionada uma função utilitária que retorna a data atual formatada PT-BR e aplicada as funções de submit dos formulários.