### PR TITLE
:wrench: Fix: Problema ao editar cedente PJ (broker)

### DIFF
--- a/src/components/Forms/CalcForm.tsx
+++ b/src/components/Forms/CalcForm.tsx
@@ -231,10 +231,6 @@ const CalcForm = ({
         }
     }, [oficioForm]);
 
-    if (data) {
-        console.log(data.properties["Credor"].title[0]?.text.content === "LUIZ INALDO - TESTE PERCENTUAIS" ? data : null);
-    }
-
     return (
         <React.Fragment>
             {hasDropzone && (

--- a/src/components/Modals/BrokersCedente/PJform.tsx
+++ b/src/components/Modals/BrokersCedente/PJform.tsx
@@ -380,6 +380,7 @@ const PJform = ({
 
     const updateCedente = useMutation({
         mutationFn: async (data: FormValuesForPJ) => {
+            
             const req = await api.patch(`/api/cedente/update/pj/${cedenteId}/`, data);
             return req.data;
         },
@@ -464,7 +465,6 @@ const PJform = ({
                 });
                 setIsFetchAllowed(true);
                 await fetchDetailCardData(id);
-                setCedenteModal(null);
             }
         } catch (error) {
             toast.error('Erro ao desvincular cedente', {
@@ -544,8 +544,11 @@ const PJform = ({
             data.celular = data.celular.replace(/\D/g, ''); // remove tudo que não for dígito
         }
 
-        data.socio_representante = registeredCedentesList.listPf?.find(
-            (cedente) => cedente.name === data.socio_representante)?.id
+        if (data.socio_representante.includes(" ")) {
+            data.socio_representante = registeredCedentesList.listPf?.find(
+                (cedente) => cedente.name === data.socio_representante)?.id
+        }
+
 
         if (mode === 'edit') {
             await updateCedente.mutateAsync(data);


### PR DESCRIPTION
# Descrição

Um problema estava sendo gerado ao salvar os dados do cedente PJ, em relação especificamente ao Representante Legal. O que acontece é que o representante legal é referenciado aos dados do formulário com um ID, enquanto os dados renderizados no front são os nomes. Quando era a primeira vez cadastrando um representate legal, não havia problema, mas quando acontecia um caso de edição, o sistema retornava erros, por que os dados inputados no formulário (no caso de já haver dados prontos para isso) no que diz respeito ao representante, se tornava o próprio nome, e não mais o ID.

A solução foi um condicional, se verifica se o valor do representante possui no mínimo um ´espaço´, indicando que o seu valor é um nome e não ID, e verificando esse caso como true, transforma o valor do formulário no ID daquele representante, enviando o dado correto para o backend.