### PR TITLE
:wrench: Fix: Ajustes na TabsList (Jurídico)

### DIFF
--- a/src/components/Dashboard/Juridico.tsx
+++ b/src/components/Dashboard/Juridico.tsx
@@ -112,7 +112,7 @@ const Juridico = () => {
             </div>
             <div className="col-span-12">
                 <Tabs defaultValue={navItems.TODOS} className="w-full">
-                    <TabsList className="tabs-scrollbar justify-normal overflow-x-auto overflow-y-hidden md:max-w-[calc(100vw-1rem)] xl:max-w-[1130px] 2xl:w-full">
+                    <TabsList className="tabs-scrollbar justify-normal overflow-x-auto overflow-y-hidden md:max-w-[calc(100vw-1rem)] xl:max-w-[1130px] 2xl:w-fit 2xl:max-w-full">
                         {Object.values(navItems).map((item, index) => (
                             <TabsTrigger
                                 key={index}


### PR DESCRIPTION
# Descrição

- TabsList estava quebrando com overflow em views maiores que `1536px`.

![image](https://github.com/user-attachments/assets/dd77285c-f89c-4b4c-a905-2b456d826219)

Definida largura de ajuste para o componente