### PR TITLE
:sparkles: Feat: Multistep loader para proposta aceita

### DIFF
--- a/src/components/Cards/DashbrokersCard.tsx
+++ b/src/components/Cards/DashbrokersCard.tsx
@@ -30,13 +30,35 @@ import Badge from '../CrmUi/ui/Badge/Badge';
 import EditOficioBrokerForm from '../Forms/EditOficioBrokerForm';
 import { IdentificationType } from '../Modals/BrokersCedente';
 import { PrintPDF } from '../PrintPDF';
+import { MultiStepLoader } from '../ui/multi-step-loader';
+import { sleep } from '@/functions/timer/sleep';
 
-export type ChecksProps = {
+export interface IChecksProps {
     is_precatorio_complete: boolean | null;
     is_cedente_complete: boolean | null;
     are_docs_complete: boolean | null;
     isFetching: boolean;
 };
+
+const loadingSteps = {
+    "accept": [
+        "Reunindo Informações" ,
+        "Verificando os Dados",
+        "Enviando Proposta",
+        "Configurando Prazos",
+        "Repassando para o Jurídico",
+        "Validando Proposta",
+        "Proposta Aceita"
+    ],
+    "decline": [
+        "Conectando com o banco de dados",
+        "Verificando os Dados",
+        "Alterando Status de Proposta",
+        "Removendo prazos",
+        "Retirando ofício do Jurídico",
+        "Retornado para Negociação",
+    ]
+}
 
 /**
  * @param {NotionPage} oficio - O ativo que vai ser carregado no componente
@@ -63,6 +85,9 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
         data: { profile_picture, first_name, last_name, phone },
     } = useContext(UserInfoAPIContext);
 
+    /** teste */
+    const [showMultiLoader, setShowMultiLoader] = useState<boolean>(false)
+
     /* ====> value states <==== */
     const [auxValues, setAuxValues] = useState<{ proposal: number; commission: number }>({
         proposal: 0,
@@ -79,11 +104,13 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
     const [savingObservation, setSavingObservation] = useState<boolean>(false);
     const [isProposalButtonDisabled, setIsProposalButtonDisabled] = useState<boolean>(true);
     const [isProposalChanging, setIsProposalChanging] = useState<boolean>(false);
+    const [proposalReqStatus, setProposalReqStatus] = useState<"success" | "failure" | null>(null);
+    const [proposalReqType, setProposalReqType] = useState<"accept" | "decline" | null>(null);
     const [errorMessage, setErrorMessage] = useState<boolean>(false);
     const [credorIdentificationType, setCredorIdentificationType] =
         useState<IdentificationType>(null);
     const [confirmModal, setOpenConfirmModal] = useState<boolean>(false);
-    const [checks, setChecks] = useState<ChecksProps>({
+    const [checks, setChecks] = useState<IChecksProps>({
         is_precatorio_complete: false,
         is_cedente_complete: false,
         are_docs_complete: false,
@@ -97,8 +124,8 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
     const proposalRef = useRef<HTMLInputElement | null>(null);
     const comissionRef = useRef<HTMLInputElement | null>(null);
     const observationRef = useRef<HTMLTextAreaElement | null>(null);
-    const proposalRangeRef = useRef<HTMLInputElement | null>(null);
     const isFirstLoad = useRef(true); // referência: 'isFirstLoad' sempre apontará para o mesmo objeto retornado por useRef
+    const multiLoaderSteps = useRef<any>([...loadingSteps.accept]);
     const [loading, setLoading] = useState<boolean>(false);
     const documentRef = useRef<HTMLDivElement>(null);
 
@@ -126,11 +153,11 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
             const req =
                 credorIdentificationType === 'CPF'
                     ? await api.get(
-                          `/api/checker/pf/complete/precatorio/${mainData?.id}/cedente/${idCedente}/`,
-                      )
+                        `/api/checker/pf/complete/precatorio/${mainData?.id}/cedente/${idCedente}/`,
+                    )
                     : await api.get(
-                          `/api/checker/pj/complete/precatorio/${mainData?.id}/cedente/${idCedente}/`,
-                      );
+                        `/api/checker/pj/complete/precatorio/${mainData?.id}/cedente/${idCedente}/`,
+                    );
 
             if (req.status === 200) {
                 setChecks((old) => ({
@@ -165,6 +192,14 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
     };
 
     /**
+     * Fecha o loader de proposta e limpa o status da requisição de proposta
+     */
+    function handleCloseLoader() {
+        setShowMultiLoader(false);
+        setProposalReqStatus(null);
+    }
+
+    /**
      * Função para atualizar a proposta e ajustar a comissão proporcionalmente
      * @param {string} value - valor da proposta
      * @param {boolean} sliderChange - indica se a mudança vem de um slider
@@ -197,8 +232,8 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
             const newComissionSliderValue =
                 (mainData?.properties['(R$) Comissão Máxima - Celer'].number || 0) -
                 proportion *
-                    ((mainData?.properties['(R$) Comissão Máxima - Celer'].number || 0) -
-                        (mainData?.properties['(R$) Comissão Mínima - Celer'].number || 0));
+                ((mainData?.properties['(R$) Comissão Máxima - Celer'].number || 0) -
+                    (mainData?.properties['(R$) Comissão Mínima - Celer'].number || 0));
 
             setSliderValues((oldValues) => {
                 return { ...oldValues, comission: newComissionSliderValue };
@@ -238,8 +273,8 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
             const newProposalSliderValue =
                 (mainData.properties['(R$) Proposta Máxima - Celer'].number || 0) -
                 proportion *
-                    ((mainData.properties['(R$) Proposta Máxima - Celer'].number || 0) -
-                        (mainData.properties['(R$) Proposta Mínima - Celer'].number || 0));
+                ((mainData.properties['(R$) Proposta Máxima - Celer'].number || 0) -
+                    (mainData.properties['(R$) Proposta Mínima - Celer'].number || 0));
 
             if (newProposalSliderValue !== auxValues.commission) {
                 setIsProposalButtonDisabled(false);
@@ -279,9 +314,9 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
             case 'proposal':
                 if (
                     numericalValue >=
-                        (oficio.properties['(R$) Proposta Mínima - Celer'].number || 0) &&
+                    (oficio.properties['(R$) Proposta Mínima - Celer'].number || 0) &&
                     numericalValue <=
-                        (oficio.properties['(R$) Proposta Máxima - Celer'].number || 0) &&
+                    (oficio.properties['(R$) Proposta Máxima - Celer'].number || 0) &&
                     !isNaN(numericalValue) &&
                     numericalValue !== auxValues.proposal
                 ) {
@@ -292,9 +327,9 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
 
                 if (
                     numericalValue <
-                        (oficio.properties['(R$) Proposta Mínima - Celer'].number || 0) ||
+                    (oficio.properties['(R$) Proposta Mínima - Celer'].number || 0) ||
                     numericalValue >
-                        (oficio.properties['(R$) Proposta Máxima - Celer'].number || 0) ||
+                    (oficio.properties['(R$) Proposta Máxima - Celer'].number || 0) ||
                     isNaN(numericalValue)
                 ) {
                     setErrorMessage(true);
@@ -314,9 +349,9 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
             case 'comission':
                 if (
                     numericalValue >=
-                        (oficio.properties['(R$) Comissão Mínima - Celer'].number || 0) &&
+                    (oficio.properties['(R$) Comissão Mínima - Celer'].number || 0) &&
                     numericalValue <=
-                        (oficio.properties['(R$) Comissão Máxima - Celer'].number || 0) &&
+                    (oficio.properties['(R$) Comissão Máxima - Celer'].number || 0) &&
                     !isNaN(numericalValue) &&
                     numericalValue !== auxValues.commission
                 ) {
@@ -327,9 +362,9 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
 
                 if (
                     numericalValue <
-                        (oficio.properties['(R$) Comissão Mínima - Celer'].number || 0) ||
+                    (oficio.properties['(R$) Comissão Mínima - Celer'].number || 0) ||
                     numericalValue >
-                        (oficio.properties['(R$) Comissão Máxima - Celer'].number || 0) ||
+                    (oficio.properties['(R$) Comissão Máxima - Celer'].number || 0) ||
                     isNaN(numericalValue)
                 ) {
                     setErrorMessage(true);
@@ -456,101 +491,105 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
         },
         onMutate: async () => {
             setIsFetchAllowed(false);
+            setShowMultiLoader(true);
             setIsProposalChanging(true);
         },
         onError: async () => {
             setIsFetchAllowed(true);
-            toast.error('Erro ao modificar proposta! Contate a Ativos para verificar o motivo.', {
-                icon: <BiX className="fill-red-500 text-lg" />,
-            });
+            setProposalReqStatus("failure");
+            // toast.error('Erro ao modificar proposta! Contate a Ativos para verificar o motivo.', {
+            //     icon: <BiX className="fill-red-500 text-lg" />,
+            // });
         },
         onSuccess: async () => {
             setIsFetchAllowed(true);
+            setProposalReqStatus("success");
             await fetchDetailCardData(mainData!.id);
-            if (
-                mainData?.properties['Status'].status?.name !== 'Proposta aceita' &&
-                checks.are_docs_complete &&
-                checks.is_cedente_complete &&
-                checks.is_precatorio_complete
-            ) {
-                confetti({
-                    spread: 180,
-                    particleCount: 300,
-                    origin: {
-                        y: 0.5,
-                    },
-                });
-                swal.fire({
-                    icon: 'success',
-                    iconColor: '#00b809',
-                    title: 'Agora é com a gente!',
-                    text: 'Nosso setor jurídico dará inicio ao processo de Due Diligence.',
-                    color: `${theme === 'light' ? '#64748B' : '#AEB7C0'}`,
-                    showConfirmButton: true,
-                    confirmButtonText: 'OK',
-                    confirmButtonColor: '#1a56db',
-                    backdrop: false,
-                    background: `${theme === 'light' ? '#FFF' : '#24303F'}`,
-                    showCloseButton: true,
-                    timer: 5000,
-                    timerProgressBar: true,
-                    didOpen: (toast) => {
-                        toast.onmouseenter = swal.stopTimer;
-                        toast.onmouseleave = swal.resumeTimer;
-                    },
-                });
-            } else if (
-                mainData?.properties['Status'].status?.name !== 'Proposta aceita' &&
-                (!checks.are_docs_complete ||
-                    !checks.is_cedente_complete ||
-                    !checks.is_precatorio_complete)
-            ) {
-                swal.fire({
-                    icon: 'info',
-                    // iconColor: "#00b809",
-                    title: 'Proposta aceita!',
-                    text: 'Porém ainda há pontos pendentes para a conclusão da diligência.',
-                    color: `${theme === 'light' ? '#64748B' : '#AEB7C0'}`,
-                    showConfirmButton: true,
-                    confirmButtonText: 'OK',
-                    confirmButtonColor: '#1a56db',
-                    backdrop: false,
-                    background: `${theme === 'light' ? '#FFF' : '#24303F'}`,
-                    showCloseButton: true,
-                    timer: 5000,
-                    timerProgressBar: true,
-                    didOpen: (toast) => {
-                        toast.onmouseenter = swal.stopTimer;
-                        toast.onmouseleave = swal.resumeTimer;
-                    },
-                });
-            } else if (mainData?.properties['Status'].status?.name === 'Proposta aceita') {
-                swal.fire({
-                    icon: 'warning',
-                    // iconColor: "#e63f66",
-                    title: 'Proposta cancelada!',
-                    text: 'Você pode registrar o motivo no campo de observação.',
-                    color: `${theme === 'light' ? '#64748B' : '#AEB7C0'}`,
-                    showConfirmButton: true,
-                    confirmButtonText: 'OK',
-                    confirmButtonColor: '#1a56db',
-                    backdrop: false,
-                    background: `${theme === 'light' ? '#FFF' : '#24303F'}`,
-                    showCloseButton: true,
-                    timer: 5000,
-                    timerProgressBar: true,
-                    didOpen: (toast) => {
-                        toast.onmouseenter = swal.stopTimer;
-                        toast.onmouseleave = swal.resumeTimer;
-                    },
-                });
-            }
+            // if (
+            //     mainData?.properties['Status'].status?.name !== 'Proposta aceita' &&
+            //     checks.are_docs_complete &&
+            //     checks.is_cedente_complete &&
+            //     checks.is_precatorio_complete
+            // ) {
+            //     confetti({
+            //         spread: 180,
+            //         particleCount: 300,
+            //         origin: {
+            //             y: 0.5,
+            //         },
+            //     });
+            //     swal.fire({
+            //         icon: 'success',
+            //         iconColor: '#00b809',
+            //         title: 'Agora é com a gente!',
+            //         text: 'Nosso setor jurídico dará inicio ao processo de Due Diligence.',
+            //         color: `${theme === 'light' ? '#64748B' : '#AEB7C0'}`,
+            //         showConfirmButton: true,
+            //         confirmButtonText: 'OK',
+            //         confirmButtonColor: '#1a56db',
+            //         backdrop: false,
+            //         background: `${theme === 'light' ? '#FFF' : '#24303F'}`,
+            //         showCloseButton: true,
+            //         timer: 5000,
+            //         timerProgressBar: true,
+            //         didOpen: (toast) => {
+            //             toast.onmouseenter = swal.stopTimer;
+            //             toast.onmouseleave = swal.resumeTimer;
+            //         },
+            //     });
+            // } else if (
+            //     mainData?.properties['Status'].status?.name !== 'Proposta aceita' &&
+            //     (!checks.are_docs_complete ||
+            //         !checks.is_cedente_complete ||
+            //         !checks.is_precatorio_complete)
+            // ) {
+            //     swal.fire({
+            //         icon: 'info',
+            //         // iconColor: "#00b809",
+            //         title: 'Proposta aceita!',
+            //         text: 'Porém ainda há pontos pendentes para a conclusão da diligência.',
+            //         color: `${theme === 'light' ? '#64748B' : '#AEB7C0'}`,
+            //         showConfirmButton: true,
+            //         confirmButtonText: 'OK',
+            //         confirmButtonColor: '#1a56db',
+            //         backdrop: false,
+            //         background: `${theme === 'light' ? '#FFF' : '#24303F'}`,
+            //         showCloseButton: true,
+            //         timer: 5000,
+            //         timerProgressBar: true,
+            //         didOpen: (toast) => {
+            //             toast.onmouseenter = swal.stopTimer;
+            //             toast.onmouseleave = swal.resumeTimer;
+            //         },
+            //     });
+            // } else if (mainData?.properties['Status'].status?.name === 'Proposta aceita') {
+            //     swal.fire({
+            //         icon: 'warning',
+            //         // iconColor: "#e63f66",
+            //         title: 'Proposta cancelada!',
+            //         text: 'Você pode registrar o motivo no campo de observação.',
+            //         color: `${theme === 'light' ? '#64748B' : '#AEB7C0'}`,
+            //         showConfirmButton: true,
+            //         confirmButtonText: 'OK',
+            //         confirmButtonColor: '#1a56db',
+            //         backdrop: false,
+            //         background: `${theme === 'light' ? '#FFF' : '#24303F'}`,
+            //         showCloseButton: true,
+            //         timer: 5000,
+            //         timerProgressBar: true,
+            //         didOpen: (toast) => {
+            //             toast.onmouseenter = swal.stopTimer;
+            //             toast.onmouseleave = swal.resumeTimer;
+            //         },
+            //     });
+            // }
         },
-        onSettled: () => {
+        onSettled: async () => {
             setIsProposalChanging(false);
+            await sleep(2);
         },
     });
-
+    
     const deleteOficio = useMutation({
         mutationFn: async (id: string) => {
             const response = await api.patch('api/notion-api/page/bulk-action/visibility/', {
@@ -630,6 +669,15 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
             mainData?.properties['Status'].status?.name === 'Proposta aceita'
                 ? 'Negociação em Andamento'
                 : 'Proposta aceita';
+        
+        if (status === 'Proposta aceita') {
+            multiLoaderSteps.current = loadingSteps.accept
+            setProposalReqType("accept");
+        } else {
+            multiLoaderSteps.current = loadingSteps.decline
+            setProposalReqType("decline");
+        }
+        
         await proposalTrigger.mutateAsync(status);
     };
 
@@ -820,14 +868,14 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
             if (proposalRef.current && comissionRef.current && observationRef.current) {
                 proposalRef.current.value = numberFormat(
                     mainData.properties['Proposta Escolhida - Celer'].number ||
-                        mainData.properties['(R$) Proposta Mínima - Celer'].number ||
-                        0,
+                    mainData.properties['(R$) Proposta Mínima - Celer'].number ||
+                    0,
                 );
 
                 comissionRef.current.value = numberFormat(
                     mainData.properties['Comissão - Celer'].number ||
-                        mainData.properties['(R$) Comissão Máxima - Celer'].number ||
-                        0,
+                    mainData.properties['(R$) Comissão Máxima - Celer'].number ||
+                    0,
                 );
 
                 observationRef.current.value =
@@ -868,7 +916,7 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
     };
 
     /**
-     * Função para gerar PDF da Proposta
+     * Gera PDF da Proposta
      */
 
     const handleGeneratePDF = useReactToPrint({
@@ -897,522 +945,552 @@ const DashbrokersCard = ({ oficio }: { oficio: NotionPage }): JSX.Element => {
         mainData?.properties['Status Diligência'].select?.name !== 'Em liquidação' &&
         mainData?.properties['Status Diligência'].select?.name !== 'Revisão Valor/LOA';
 
-    return (
-        <div className="relative col-span-1 gap-5 rounded-md border border-stroke bg-white p-5 dark:border-strokedark dark:bg-boxdark">
-            {/* ----> info <----- */}
-            <div className="mb-2 flex items-center justify-between">
-                <div className={`flex w-fit items-center justify-center gap-2 opacity-50 pointer-events-none ${(checks.are_docs_complete || checks.is_cedente_complete || checks.is_precatorio_complete) && "!opacity-100 !pointer-events-auto"}`}>
-                    {isProposalChanging ? (
-                        <AiOutlineLoading className="animate-spin" />
-                    ) : (
-                        <CustomCheckbox
-                            check={
-                                mainData?.properties['Status'].status?.name === 'Proposta aceita'
-                            }
-                            callbackFunction={handleUpdateStatus}
-                        />
-                    )}
-                    <span className="text-sm font-medium">Proposta Aceita</span>
-                </div>
+    /** teste */
 
-                <div className="flex items-center gap-3">
-                    <button
-                        disabled={deleteModalLock}
-                        className="group flex h-[28px] w-[28px] cursor-pointer items-center justify-center overflow-hidden rounded-full border-transparent bg-slate-100 px-0 py-0 opacity-100 transition-all duration-300 ease-in-out hover:w-[100px] hover:bg-slate-200 disabled:pointer-events-none disabled:opacity-0 dark:bg-slate-700 dark:hover:bg-slate-700"
-                        onClick={() => {
-                            setOpenConfirmModal(true);
-                            setDeleteModalLock(true);
-                        }}
-                    >
-                        {isDeleting ? (
+    const handleMultiLoader = () => {
+        setShowMultiLoader(true);
+        setTimeout(() => {
+            console.log("a")
+            // setShowMultiLoader(false)
+        }, 10000)
+    }
+
+    return (
+        <>
+            <div className="relative col-span-1 gap-5 rounded-md border border-stroke bg-white p-5 dark:border-strokedark dark:bg-boxdark">
+                {/* ----> info <----- */}
+                <div className="mb-2 flex items-center justify-between">
+                    <div className={`flex w-fit items-center justify-center gap-2 opacity-50 pointer-events-none ${(checks.are_docs_complete || checks.is_cedente_complete || checks.is_precatorio_complete) && "!opacity-100 !pointer-events-auto"}`}>
+                        {isProposalChanging ? (
                             <AiOutlineLoading className="animate-spin" />
                         ) : (
-                            <>
-                                <BiTrash className=" max-w-4 overflow-hidden opacity-100 transition-width duration-300 group-hover:max-w-0 group-hover:opacity-0" />
-
-                                <div className=" max-w-0 overflow-hidden whitespace-nowrap text-sm opacity-0 transition-opacity duration-500 ease-in-out group-hover:max-w-[76px] group-hover:opacity-100">
-                                    Excluir Ativo
-                                </div>
-                            </>
+                            <CustomCheckbox
+                                check={
+                                    mainData?.properties['Status'].status?.name === 'Proposta aceita'
+                                }
+                                callbackFunction={handleUpdateStatus}
+                            />
                         )}
-                    </button>
+                        <span className="text-sm font-medium">Proposta Aceita</span>
+                        <Button onClick={handleMultiLoader} variant={"ghost"}>
+                            multi loader
+                        </Button>
+                    </div>
 
-                    <Button
-                        title="Atualizar informações do ativo"
-                        variant="ghost"
-                        className="group flex h-7 w-7 items-center justify-center rounded-full bg-slate-100 px-0 py-0 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600"
-                        onClick={handleRefreshCard}
-                    >
-                        <BiRefresh className={`${isFetchingData && 'animate-spin'}`} />
-                    </Button>
-                </div>
-            </div>
-            <hr className="mb-4 border border-stroke dark:border-strokedark" />
-            <div className="grid 2xsm:grid-cols-12 md:grid-cols-8 xl:grid-cols-12">
-                <div className="col-span-12 grid min-w-[248px] gap-3 md:col-span-8 md:min-w-fit xl:col-span-6">
-                    <div className="text-xs">
-                        <p className="font-medium uppercase text-black dark:text-snow">
-                            Nome do Credor:
-                        </p>
-                        <CRMTooltip
-                            text={
-                                mainData?.properties['Credor'].title[0]?.text.content ||
-                                'Não informado'
-                            }
-                            arrow={false}
+                    <div className="flex items-center gap-3">
+                        <button
+                            disabled={deleteModalLock}
+                            className="group flex h-[28px] w-[28px] cursor-pointer items-center justify-center overflow-hidden rounded-full border-transparent bg-slate-100 px-0 py-0 opacity-100 transition-all duration-300 ease-in-out hover:w-[100px] hover:bg-slate-200 disabled:pointer-events-none disabled:opacity-0 dark:bg-slate-700 dark:hover:bg-slate-700"
+                            onClick={() => {
+                                setOpenConfirmModal(true);
+                                setDeleteModalLock(true);
+                            }}
                         >
-                            <p className="overflow-hidden text-ellipsis whitespace-nowrap text-sm font-semibold uppercase md:max-w-[220px]">
-                                {mainData?.properties['Credor'].title[0]?.text.content ||
+                            {isDeleting ? (
+                                <AiOutlineLoading className="animate-spin" />
+                            ) : (
+                                <>
+                                    <BiTrash className=" max-w-4 overflow-hidden opacity-100 transition-width duration-300 group-hover:max-w-0 group-hover:opacity-0" />
+
+                                    <div className=" max-w-0 overflow-hidden whitespace-nowrap text-sm opacity-0 transition-opacity duration-500 ease-in-out group-hover:max-w-[76px] group-hover:opacity-100">
+                                        Excluir Ativo
+                                    </div>
+                                </>
+                            )}
+                        </button>
+
+                        <Button
+                            title="Atualizar informações do ativo"
+                            variant="ghost"
+                            className="group flex h-7 w-7 items-center justify-center rounded-full bg-slate-100 px-0 py-0 hover:bg-slate-200 dark:bg-slate-700 dark:hover:bg-slate-600"
+                            onClick={handleRefreshCard}
+                        >
+                            <BiRefresh className={`${isFetchingData && 'animate-spin'}`} />
+                        </Button>
+                    </div>
+                </div>
+                <hr className="mb-4 border border-stroke dark:border-strokedark" />
+                <div className="grid 2xsm:grid-cols-12 md:grid-cols-8 xl:grid-cols-12">
+                    <div className="col-span-12 grid min-w-[248px] gap-3 md:col-span-8 md:min-w-fit xl:col-span-6">
+                        <div className="text-xs">
+                            <p className="font-medium uppercase text-black dark:text-snow">
+                                Nome do Credor:
+                            </p>
+                            <CRMTooltip
+                                text={
+                                    mainData?.properties['Credor'].title[0]?.text.content ||
+                                    'Não informado'
+                                }
+                                arrow={false}
+                            >
+                                <p className="overflow-hidden text-ellipsis whitespace-nowrap text-sm font-semibold uppercase md:max-w-[220px]">
+                                    {mainData?.properties['Credor'].title[0]?.text.content ||
+                                        'Não informado'}
+                                </p>
+                            </CRMTooltip>
+                        </div>
+
+                        <div className="text-xs">
+                            <p className="font-medium uppercase text-black dark:text-snow">CPF/CNPJ:</p>
+                            <p className="text-sm font-semibold uppercase">
+                                {applyMaskCpfCnpj(
+                                    mainData?.properties['CPF/CNPJ'].rich_text?.[0]?.text?.content ||
+                                    '',
+                                ) || 'Não informado'}
+                            </p>
+                        </div>
+
+                        <div className="text-xs">
+                            <p className="font-medium uppercase text-black dark:text-snow">TRIBUNAL</p>
+                            <p className="max-w-[220px] overflow-hidden text-ellipsis whitespace-nowrap text-sm font-semibold uppercase">
+                                {mainData?.properties['Tribunal'].select?.name || 'Não informado'}
+                            </p>
+                        </div>
+
+                        <div className="text-xs">
+                            <p className="font-medium uppercase text-black dark:text-snow">status:</p>
+                            <p className="text-sm font-semibold uppercase">
+                                {mainData?.properties['Status'].status?.name || 'Não informado'}
+                            </p>
+                        </div>
+                        <div className="text-xs">
+                            <p className="font-medium uppercase text-black dark:text-snow">
+                                status diligência:
+                            </p>
+                            <p className="text-sm font-semibold uppercase">
+                                {mainData?.properties['Status Diligência'].select?.name ||
                                     'Não informado'}
                             </p>
-                        </CRMTooltip>
-                    </div>
+                        </div>
 
-                    <div className="text-xs">
-                        <p className="font-medium uppercase text-black dark:text-snow">CPF/CNPJ:</p>
-                        <p className="text-sm font-semibold uppercase">
-                            {applyMaskCpfCnpj(
-                                mainData?.properties['CPF/CNPJ'].rich_text?.[0]?.text?.content ||
-                                    '',
-                            ) || 'Não informado'}
-                        </p>
-                    </div>
-
-                    <div className="text-xs">
-                        <p className="font-medium uppercase text-black dark:text-snow">TRIBUNAL</p>
-                        <p className="max-w-[220px] overflow-hidden text-ellipsis whitespace-nowrap text-sm font-semibold uppercase">
-                            {mainData?.properties['Tribunal'].select?.name || 'Não informado'}
-                        </p>
-                    </div>
-
-                    <div className="text-xs">
-                        <p className="font-medium uppercase text-black dark:text-snow">status:</p>
-                        <p className="text-sm font-semibold uppercase">
-                            {mainData?.properties['Status'].status?.name || 'Não informado'}
-                        </p>
-                    </div>
-                    <div className="text-xs">
-                        <p className="font-medium uppercase text-black dark:text-snow">
-                            status diligência:
-                        </p>
-                        <p className="text-sm font-semibold uppercase">
-                            {mainData?.properties['Status Diligência'].select?.name ||
-                                'Não informado'}
-                        </p>
-                    </div>
-
-                    <div className="flex min-w-fit flex-col">
-                        <div className="relative w-full">
-                            {mainData?.properties['Status Diligência'].select?.name !==
-                                'Due Diligence' &&
-                                mainData?.properties['Status Diligência'].select?.name !==
+                        <div className="flex min-w-fit flex-col">
+                            <div className="relative w-full">
+                                {mainData?.properties['Status Diligência'].select?.name !==
+                                    'Due Diligence' &&
+                                    mainData?.properties['Status Diligência'].select?.name !==
                                     'Em liquidação' &&
-                                mainData?.properties['Status Diligência'].select?.name !==
+                                    mainData?.properties['Status Diligência'].select?.name !==
                                     'Revisão Valor/LOA' &&
-                                mainData?.properties['Status'].status?.name === 'Proposta aceita' &&
-                                checks.is_cedente_complete === true &&
-                                checks.is_precatorio_complete === true &&
-                                checks.are_docs_complete === true && (
-                                    <span className="span-pulse absolute z-1 h-full w-full rounded-md bg-green-300"></span>
-                                )}
+                                    mainData?.properties['Status'].status?.name === 'Proposta aceita' &&
+                                    checks.is_cedente_complete === true &&
+                                    checks.is_precatorio_complete === true &&
+                                    checks.are_docs_complete === true && (
+                                        <span className="span-pulse absolute z-1 h-full w-full rounded-md bg-green-300"></span>
+                                    )}
+
+                                <button
+                                    onClick={handleLiquidateCard}
+                                    className={`${mainData?.properties['Status Diligência'].select?.name.valueOf() !== 'Due Diligence' && mainData?.properties['Status Diligência'].select?.name !== 'Em liquidação' && mainData?.properties['Status Diligência'].select?.name !== 'Revisão Valor/LOA' && mainData?.properties['Status'].status?.name === 'Proposta aceita' && checks.is_cedente_complete === true && checks.is_precatorio_complete === true && checks.are_docs_complete === true ? 'bg-green-400 text-black-2 hover:bg-green-500 hover:text-snow' : 'pointer-events-none cursor-not-allowed bg-slate-100 opacity-50 dark:bg-boxdark-2/50'} relative z-2 my-1 flex w-full items-center justify-center gap-2 rounded-md px-4 py-1 text-sm transition-colors duration-200`}
+                                >
+                                    {isUpdatingDiligence ? (
+                                        <>
+                                            <AiOutlineLoading className="h-4 w-4 animate-spin" />
+                                            {validateIfItsLockedWhenStatusDiligenceBeDifferent &&
+                                                mainData?.properties['Status'].status?.name ===
+                                                'Proposta aceita'
+                                                ? 'Liquidando...'
+                                                : 'Repactuando...'}
+                                        </>
+                                    ) : (
+                                        <>
+                                            {validateStatusLocked &&
+                                                mainData?.properties['Status'].status?.name ===
+                                                'Proposta aceita' ? (
+                                                <>
+                                                    <HiCheck className="h-4 w-4" />
+                                                    Liquidado
+                                                </>
+                                            ) : (
+                                                <>
+                                                    {mainData?.properties['Status Diligência'].select
+                                                        ?.name === 'Repactuação' ? (
+                                                        <>
+                                                            <HiCheck className="h-4 w-4" />
+                                                            Repactuar
+                                                        </>
+                                                    ) : (
+                                                        <>
+                                                            <HiCheck className="h-4 w-4" />
+                                                            Liquidar
+                                                        </>
+                                                    )}
+                                                </>
+                                            )}
+                                        </>
+                                    )}
+                                </button>
+                            </div>
 
                             <button
-                                onClick={handleLiquidateCard}
-                                className={`${mainData?.properties['Status Diligência'].select?.name.valueOf() !== 'Due Diligence' && mainData?.properties['Status Diligência'].select?.name !== 'Em liquidação' && mainData?.properties['Status Diligência'].select?.name !== 'Revisão Valor/LOA' && mainData?.properties['Status'].status?.name === 'Proposta aceita' && checks.is_cedente_complete === true && checks.is_precatorio_complete === true && checks.are_docs_complete === true ? 'bg-green-400 text-black-2 hover:bg-green-500 hover:text-snow' : 'pointer-events-none cursor-not-allowed bg-slate-100 opacity-50 dark:bg-boxdark-2/50'} relative z-2 my-1 flex w-full items-center justify-center gap-2 rounded-md px-4 py-1 text-sm transition-colors duration-200`}
+                                onClick={() => setEditModalId(mainData!.id)}
+                                disabled={
+                                    checks.isFetching ||
+                                    (mainData?.properties['Status'].status?.name ===
+                                        'Proposta aceita' &&
+                                        validateIfItsLockedWhenStatusDiligenceBeEqual) ||
+                                    mainData?.properties['Status Diligência'].select?.name ===
+                                    'Em liquidação' ||
+                                    (mainData?.properties['Status'].status?.name ===
+                                        'Proposta aceita' &&
+                                        mainData?.properties['Status Diligência'].select?.name ===
+                                        'Juntar Documentos')
+                                }
+                                className="my-1 flex items-center justify-center gap-2 rounded-md bg-slate-100 px-4 py-1 text-sm transition-colors duration-300 hover:bg-slate-200 disabled:pointer-events-none disabled:opacity-50 dark:bg-boxdark-2/50 dark:hover:bg-boxdark-2/70"
                             >
-                                {isUpdatingDiligence ? (
+                                <BsPencilSquare />
+                                Editar Precatório
+                            </button>
+
+                            <button
+                                onClick={() => setDocModalInfo(mainData)}
+                                className={`${checks.is_cedente_complete !== false ? 'opacity-100' : 'pointer-events-none cursor-not-allowed opacity-50'} my-1 flex items-center justify-center gap-2 rounded-md bg-slate-100 px-4 py-1 text-sm transition-colors duration-300 hover:bg-slate-200 dark:bg-boxdark-2/50 dark:hover:bg-boxdark-2/70`}
+                            >
+                                <FaRegFilePdf />
+                                Juntar Documentos
+                            </button>
+
+                            <button
+                                onClick={() => setCedenteModal(mainData)}
+                                disabled={
+                                    (mainData &&
+                                        mainData?.properties['CPF/CNPJ']?.rich_text?.length === 0) ||
+                                    undefined
+                                }
+                                className="my-1 flex items-center justify-center gap-2 rounded-md bg-slate-100 px-4 py-1 text-sm transition-colors duration-300 hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-boxdark-2/50 dark:hover:bg-boxdark-2/70"
+                            >
+                                {mainData?.properties['Cedente PF'].relation?.[0] ||
+                                    mainData?.properties['Cedente PJ'].relation?.[0] ? (
                                     <>
-                                        <AiOutlineLoading className="h-4 w-4 animate-spin" />
-                                        {validateIfItsLockedWhenStatusDiligenceBeDifferent &&
-                                        mainData?.properties['Status'].status?.name ===
-                                            'Proposta aceita'
-                                            ? 'Liquidando...'
-                                            : 'Repactuando...'}
+                                        <BsPencilSquare />
+                                        Editar Cedente
                                     </>
                                 ) : (
                                     <>
-                                        {validateStatusLocked &&
-                                        mainData?.properties['Status'].status?.name ===
-                                            'Proposta aceita' ? (
-                                            <>
-                                                <HiCheck className="h-4 w-4" />
-                                                Liquidado
-                                            </>
-                                        ) : (
-                                            <>
-                                                {mainData?.properties['Status Diligência'].select
-                                                    ?.name === 'Repactuação' ? (
-                                                    <>
-                                                        <HiCheck className="h-4 w-4" />
-                                                        Repactuar
-                                                    </>
-                                                ) : (
-                                                    <>
-                                                        <HiCheck className="h-4 w-4" />
-                                                        Liquidar
-                                                    </>
-                                                )}
-                                            </>
-                                        )}
+                                        <GrDocumentUser />
+                                        Cadastrar Cedente
                                     </>
                                 )}
                             </button>
                         </div>
 
-                        <button
-                            onClick={() => setEditModalId(mainData!.id)}
-                            disabled={
-                                checks.isFetching ||
-                                (mainData?.properties['Status'].status?.name ===
-                                    'Proposta aceita' &&
-                                    validateIfItsLockedWhenStatusDiligenceBeEqual) ||
-                                mainData?.properties['Status Diligência'].select?.name ===
-                                    'Em liquidação' ||
-                                (mainData?.properties['Status'].status?.name ===
-                                    'Proposta aceita' &&
-                                    mainData?.properties['Status Diligência'].select?.name ===
-                                        'Juntar Documentos')
-                            }
-                            className="my-1 flex items-center justify-center gap-2 rounded-md bg-slate-100 px-4 py-1 text-sm transition-colors duration-300 hover:bg-slate-200 disabled:pointer-events-none disabled:opacity-50 dark:bg-boxdark-2/50 dark:hover:bg-boxdark-2/70"
-                        >
-                            <BsPencilSquare />
-                            Editar Precatório
-                        </button>
-
-                        <button
-                            onClick={() => setDocModalInfo(mainData)}
-                            className={`${checks.is_cedente_complete !== false ? 'opacity-100' : 'pointer-events-none cursor-not-allowed opacity-50'} my-1 flex items-center justify-center gap-2 rounded-md bg-slate-100 px-4 py-1 text-sm transition-colors duration-300 hover:bg-slate-200 dark:bg-boxdark-2/50 dark:hover:bg-boxdark-2/70`}
-                        >
-                            <FaRegFilePdf />
-                            Juntar Documentos
-                        </button>
-
-                        <button
-                            onClick={() => setCedenteModal(mainData)}
-                            disabled={
-                                (mainData &&
-                                    mainData?.properties['CPF/CNPJ']?.rich_text?.length === 0) ||
-                                undefined
-                            }
-                            className="my-1 flex items-center justify-center gap-2 rounded-md bg-slate-100 px-4 py-1 text-sm transition-colors duration-300 hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-boxdark-2/50 dark:hover:bg-boxdark-2/70"
-                        >
-                            {mainData?.properties['Cedente PF'].relation?.[0] ||
-                            mainData?.properties['Cedente PJ'].relation?.[0] ? (
-                                <>
-                                    <BsPencilSquare />
-                                    Editar Cedente
-                                </>
-                            ) : (
-                                <>
-                                    <GrDocumentUser />
-                                    Cadastrar Cedente
-                                </>
-                            )}
-                        </button>
-                    </div>
-
-                    <div className="flex items-center justify-between gap-2">
-                        <div className="flex items-center gap-2">
-                            {checks.isFetching && isFirstLoad.current ? (
-                                <AiOutlineLoading className="h-4 w-4 animate-spin" />
-                            ) : (
-                                <>
-                                    {checks.is_precatorio_complete ? (
-                                        <CRMTooltip text="Precatório completo">
-                                            <BsCheckCircleFill className="text-green-400" />
-                                        </CRMTooltip>
-                                    ) : (
-                                        <CRMTooltip text="Precatório incompleto">
-                                            <IoCloseCircle className="h-5 w-5 text-red" />
-                                        </CRMTooltip>
-                                    )}
-                                </>
-                            )}
-
-                            {checks.isFetching && isFirstLoad.current ? (
-                                <AiOutlineLoading className="h-4 w-4 animate-spin" />
-                            ) : (
-                                <>
-                                    {checks.is_cedente_complete === true && (
-                                        <CRMTooltip text="Cedente preenchido">
-                                            <BsCheckCircleFill className="text-green-400" />
-                                        </CRMTooltip>
-                                    )}
-                                    {checks.is_cedente_complete === null && (
-                                        <CRMTooltip text="Cedente incompleto">
-                                            <RiErrorWarningFill className="h-5 w-5 text-amber-300" />
-                                        </CRMTooltip>
-                                    )}
-                                    {checks.is_cedente_complete === false && (
-                                        <CRMTooltip text="Cedente não vinculado">
-                                            <IoCloseCircle className="h-5 w-5 text-red" />
-                                        </CRMTooltip>
-                                    )}
-                                </>
-                            )}
-
-                            {checks.isFetching && isFirstLoad.current ? (
-                                <AiOutlineLoading className="h-4 w-4 animate-spin" />
-                            ) : (
-                                <>
-                                    {checks.are_docs_complete === true && (
-                                        <CRMTooltip text="Documentos preenchidos">
-                                            <BsCheckCircleFill className="text-green-400" />
-                                        </CRMTooltip>
-                                    )}
-                                    {checks.are_docs_complete === null && (
-                                        <CRMTooltip text="Documentos em análise">
-                                            <RiErrorWarningFill className="h-5 w-5 text-amber-300" />
-                                        </CRMTooltip>
-                                    )}
-                                    {checks.are_docs_complete === false && (
-                                        <CRMTooltip text="Documentos não vinculados">
-                                            <IoCloseCircle className="h-5 w-5 text-red" />
-                                        </CRMTooltip>
-                                    )}
-                                </>
-                            )}
-                            {/* TODO: Esse aqui será o check para verificação do anuente quando a implementação for desenvolvida */}
-                            {/* <MdOutlineCircle className='w-4 h-4' /> */}
-                        </div>
-                        <div className="flex items-center gap-2">
-                            <Badge isANotionPage color={mainData?.properties['Tipo'].select?.color}>
-                                <Badge.Label
-                                    label={
-                                        mainData?.properties['Tipo'].select?.name ?? 'Não informado'
-                                    }
-                                />
-                            </Badge>
-                            <Badge
-                                isANotionPage
-                                color={mainData?.properties['Esfera'].select?.color}
-                            >
-                                <Badge.Label
-                                    label={
-                                        mainData?.properties['Esfera'].select?.name ??
-                                        'Não informado'
-                                    }
-                                />
-                            </Badge>
-                        </div>
-                    </div>
-                </div>
-
-                <ConfirmModal
-                    size="lg"
-                    isOpen={confirmModal}
-                    onClose={() => {
-                        setOpenConfirmModal(false);
-                        setDeleteModalLock(false);
-                    }}
-                    onConfirm={() => handleDeleteOficio(mainData!.id)}
-                    isLoading={isDeleting}
-                />
-
-                <div className="col-span-12 mx-2 mt-5 grid gap-5 border-l-0 border-t-2 border-stroke pl-0 pt-5 dark:border-strokedark md:col-span-8 md:mt-0 md:border-l-2 md:border-t-0 md:pl-3 md:pt-5 xl:col-span-6">
-                    <div className="relative flex max-h-fit flex-col gap-5 pb-8 sm:pb-0">
-                        <div className="flex items-center justify-between gap-6 2xsm:flex-col md:flex-row">
-                            <div className="flex w-full flex-1 flex-col items-center gap-4 pb-2 2xsm:pb-0 md:pb-2">
-                                <div className="flex items-center text-sm font-medium">
-                                    <p className="w-full text-sm">Proposta:</p>
-                                    <input
-                                        ref={proposalRef}
-                                        type="text"
-                                        disabled={
-                                            (mainData?.properties['Status'].status?.name ===
-                                                'Proposta aceita' &&
-                                                validateIfItsLockedWhenStatusDiligenceBeEqual) ||
-                                            (mainData?.properties['Status'].status?.name ===
-                                                'Proposta aceita' &&
-                                                mainData?.properties['Status Diligência'].select
-                                                    ?.name === 'Juntar Documentos') ||
-                                            (mainData?.properties['Status'].status?.name ===
-                                                'Proposta aceita' &&
-                                                mainData?.properties['Status Diligência'].select
-                                                    ?.name === 'Pendência a Sanar')
-                                        }
-                                        onBlur={(e) => {
-                                            e.target.value = formatCurrency(e.target.value);
-                                        }}
-                                        onChange={(e) =>
-                                            changeInputValues('proposal', e.target.value)
-                                        }
-                                        className="ml-2 max-w-35 rounded-md border-none bg-gray-100 py-2 pl-1 pr-2 text-center text-sm font-medium text-body focus-visible:ring-body disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 dark:bg-boxdark-2/50 dark:text-bodydark dark:focus-visible:ring-snow"
-                                    />
-                                </div>
-                                <input
-                                    // ref={proposalRangeRef}
-                                    type="range"
-                                    step="0.01"
-                                    disabled={
-                                        (mainData?.properties['Status'].status?.name ===
-                                            'Proposta aceita' &&
-                                            validateIfItsLockedWhenStatusDiligenceBeEqual) ||
-                                        (mainData?.properties['Status'].status?.name ===
-                                            'Proposta aceita' &&
-                                            mainData?.properties['Status Diligência'].select
-                                                ?.name === 'Juntar Documentos') ||
-                                        (mainData?.properties['Status'].status?.name ===
-                                            'Proposta aceita' &&
-                                            mainData?.properties['Status Diligência'].select
-                                                ?.name === 'Pendência a Sanar')
-                                    }
-                                    min={
-                                        mainData?.properties['(R$) Proposta Mínima - Celer']
-                                            .number || 0
-                                    }
-                                    max={
-                                        mainData?.properties['(R$) Proposta Máxima - Celer']
-                                            .number || 0
-                                    }
-                                    value={sliderValues.proposal}
-                                    onChange={(e) =>
-                                        handleProposalSliderChange(e.target.value, true)
-                                    }
-                                    className="range-slider w-full disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-50"
-                                />
-                            </div>
-                        </div>
-
-                        <div className="relative flex items-center justify-between gap-5 2xsm:flex-col md:flex-row">
-                            <div className="flex w-full flex-1 flex-col items-center gap-4">
-                                <div className="flex items-center text-sm font-medium ">
-                                    <p className="text-sm">Comissão:</p>
-                                    <input
-                                        ref={comissionRef}
-                                        type="text"
-                                        disabled={
-                                            (mainData?.properties['Status'].status?.name ===
-                                                'Proposta aceita' &&
-                                                validateIfItsLockedWhenStatusDiligenceBeEqual) ||
-                                            (mainData?.properties['Status'].status?.name ===
-                                                'Proposta aceita' &&
-                                                mainData?.properties['Status Diligência'].select
-                                                    ?.name === 'Juntar Documentos') ||
-                                            (mainData?.properties['Status'].status?.name ===
-                                                'Proposta aceita' &&
-                                                mainData?.properties['Status Diligência'].select
-                                                    ?.name === 'Pendência a Sanar')
-                                        }
-                                        onBlur={(e) => {
-                                            e.target.value = formatCurrency(e.target.value);
-                                        }}
-                                        onChange={(e) =>
-                                            changeInputValues('comission', e.target.value)
-                                        }
-                                        className="ml-2 max-w-35 rounded-md border-none bg-gray-100 py-2 pl-1 pr-2 text-center text-sm font-medium text-body focus-visible:ring-body disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 dark:bg-boxdark-2/50 dark:text-bodydark dark:focus-visible:ring-snow"
-                                    />
-                                </div>
-                                <input
-                                    type="range"
-                                    step="0.01"
-                                    disabled={
-                                        (mainData?.properties['Status'].status?.name ===
-                                            'Proposta aceita' &&
-                                            validateIfItsLockedWhenStatusDiligenceBeEqual) ||
-                                        (mainData?.properties['Status'].status?.name ===
-                                            'Proposta aceita' &&
-                                            mainData?.properties['Status Diligência'].select
-                                                ?.name === 'Juntar Documentos') ||
-                                        (mainData?.properties['Status'].status?.name ===
-                                            'Proposta aceita' &&
-                                            mainData?.properties['Status Diligência'].select
-                                                ?.name === 'Pendência a Sanar')
-                                    }
-                                    min={
-                                        mainData?.properties['(R$) Comissão Mínima - Celer']
-                                            .number || 0
-                                    }
-                                    max={
-                                        mainData?.properties['(R$) Comissão Máxima - Celer']
-                                            .number || 0
-                                    }
-                                    value={sliderValues.comission}
-                                    onChange={(e) =>
-                                        handleComissionSliderChange(e.target.value, true)
-                                    }
-                                    className="range-slider-reverse [::-webkit-slider-thumb]::-webkit-slider-thumb {background-color: #FFF;} w-full disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-50"
-                                />
-                            </div>
-                        </div>
-
-                        {errorMessage && (
-                            <div className="absolute -bottom-4 w-full text-center text-xs text-red">
-                                Valor&#40;res&#41; fora do escopo definido
-                            </div>
-                        )}
-                    </div>
-                    <div className="flex gap-2">
-                        <Button
-                            disabled={isProposalButtonDisabled}
-                            onClick={saveProposalAndComission}
-                            className="h-8 w-full px-2 py-1 text-sm font-medium transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50"
-                        >
-                            {savingProposalAndComission ? 'Salvando...' : 'Salvar Oferta'}
-                        </Button>
-                        <Button
-                            isLoading={loading}
-                            onClick={() => handleGeneratePDF()}
-                            className="h-8 w-full px-2 text-sm font-medium transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50"
-                        >
-                            Gerar Proposta
-                        </Button>
-                    </div>
-                    {/* Esse componente tem a função apenas de gerar um PDF, por isso hidden */}
-                    <div className="hidden">
-                        <div ref={documentRef} className="bg-[#F4F4F4]">
-                            <PrintPDF
-                                nomeDoCredor={mainData?.properties['Credor'].title[0]?.text.content}
-                                valorDaProposta={
-                                    mainData?.properties['Proposta Escolhida - Celer'].number ||
-                                    mainData?.properties['(R$) Proposta Mínima - Celer'].number ||
-                                    0
-                                }
-                                nomeDoBroker={first_name + ' ' + last_name}
-                                fotoDoBroker={profile_picture}
-                                phone={phone ? phone : null}
-                            />
-                        </div>
-                    </div>
-
-                    {/* separator */}
-
-                    {/* end separator */}
-
-                    {/* ----> observations field <----- */}
-                    <div className="h-full w-full">
-                        <p className="mb-2">Observações:</p>
-                        <div className="relative">
-                            <textarea
-                                ref={observationRef}
-                                className="w-full resize-none rounded-md border-stroke placeholder:text-sm dark:border-strokedark dark:bg-boxdark-2/50"
-                                rows={4}
-                                placeholder="Insira uma observação"
-                            />
-                            <Button
-                                variant="ghost"
-                                onClick={() =>
-                                    handleUpdateObservation(observationRef.current?.value || '')
-                                }
-                                className="absolute bottom-3 right-2 z-2 bg-slate-100 px-1 py-1 text-sm hover:bg-slate-200 dark:bg-boxdark-2/50 dark:hover:bg-boxdark-2/70"
-                            >
-                                {savingObservation ? (
-                                    <AiOutlineLoading className="animate-spin text-lg" />
+                        <div className="flex items-center justify-between gap-2">
+                            <div className="flex items-center gap-2">
+                                {checks.isFetching && isFirstLoad.current ? (
+                                    <AiOutlineLoading className="h-4 w-4 animate-spin" />
                                 ) : (
-                                    <BiSave className="text-lg" />
+                                    <>
+                                        {checks.is_precatorio_complete ? (
+                                            <CRMTooltip text="Precatório completo">
+                                                <BsCheckCircleFill className="text-green-400" />
+                                            </CRMTooltip>
+                                        ) : (
+                                            <CRMTooltip text="Precatório incompleto">
+                                                <IoCloseCircle className="h-5 w-5 text-red" />
+                                            </CRMTooltip>
+                                        )}
+                                    </>
                                 )}
+
+                                {checks.isFetching && isFirstLoad.current ? (
+                                    <AiOutlineLoading className="h-4 w-4 animate-spin" />
+                                ) : (
+                                    <>
+                                        {checks.is_cedente_complete === true && (
+                                            <CRMTooltip text="Cedente preenchido">
+                                                <BsCheckCircleFill className="text-green-400" />
+                                            </CRMTooltip>
+                                        )}
+                                        {checks.is_cedente_complete === null && (
+                                            <CRMTooltip text="Cedente incompleto">
+                                                <RiErrorWarningFill className="h-5 w-5 text-amber-300" />
+                                            </CRMTooltip>
+                                        )}
+                                        {checks.is_cedente_complete === false && (
+                                            <CRMTooltip text="Cedente não vinculado">
+                                                <IoCloseCircle className="h-5 w-5 text-red" />
+                                            </CRMTooltip>
+                                        )}
+                                    </>
+                                )}
+
+                                {checks.isFetching && isFirstLoad.current ? (
+                                    <AiOutlineLoading className="h-4 w-4 animate-spin" />
+                                ) : (
+                                    <>
+                                        {checks.are_docs_complete === true && (
+                                            <CRMTooltip text="Documentos preenchidos">
+                                                <BsCheckCircleFill className="text-green-400" />
+                                            </CRMTooltip>
+                                        )}
+                                        {checks.are_docs_complete === null && (
+                                            <CRMTooltip text="Documentos em análise">
+                                                <RiErrorWarningFill className="h-5 w-5 text-amber-300" />
+                                            </CRMTooltip>
+                                        )}
+                                        {checks.are_docs_complete === false && (
+                                            <CRMTooltip text="Documentos não vinculados">
+                                                <IoCloseCircle className="h-5 w-5 text-red" />
+                                            </CRMTooltip>
+                                        )}
+                                    </>
+                                )}
+                                {/* TODO: Esse aqui será o check para verificação do anuente quando a implementação for desenvolvida */}
+                                {/* <MdOutlineCircle className='w-4 h-4' /> */}
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <Badge isANotionPage color={mainData?.properties['Tipo'].select?.color}>
+                                    <Badge.Label
+                                        label={
+                                            mainData?.properties['Tipo'].select?.name ?? 'Não informado'
+                                        }
+                                    />
+                                </Badge>
+                                <Badge
+                                    isANotionPage
+                                    color={mainData?.properties['Esfera'].select?.color}
+                                >
+                                    <Badge.Label
+                                        label={
+                                            mainData?.properties['Esfera'].select?.name ??
+                                            'Não informado'
+                                        }
+                                    />
+                                </Badge>
+                            </div>
+                        </div>
+                    </div>
+
+                    <ConfirmModal
+                        size="lg"
+                        isOpen={confirmModal}
+                        onClose={() => {
+                            setOpenConfirmModal(false);
+                            setDeleteModalLock(false);
+                        }}
+                        onConfirm={() => handleDeleteOficio(mainData!.id)}
+                        isLoading={isDeleting}
+                    />
+
+                    <div className="col-span-12 mx-2 mt-5 grid gap-5 border-l-0 border-t-2 border-stroke pl-0 pt-5 dark:border-strokedark md:col-span-8 md:mt-0 md:border-l-2 md:border-t-0 md:pl-3 md:pt-5 xl:col-span-6">
+                        <div className="relative flex max-h-fit flex-col gap-5 pb-8 sm:pb-0">
+                            <div className="flex items-center justify-between gap-6 2xsm:flex-col md:flex-row">
+                                <div className="flex w-full flex-1 flex-col items-center gap-4 pb-2 2xsm:pb-0 md:pb-2">
+                                    <div className="flex items-center text-sm font-medium">
+                                        <p className="w-full text-sm">Proposta:</p>
+                                        <input
+                                            ref={proposalRef}
+                                            type="text"
+                                            disabled={
+                                                (mainData?.properties['Status'].status?.name ===
+                                                    'Proposta aceita' &&
+                                                    validateIfItsLockedWhenStatusDiligenceBeEqual) ||
+                                                (mainData?.properties['Status'].status?.name ===
+                                                    'Proposta aceita' &&
+                                                    mainData?.properties['Status Diligência'].select
+                                                        ?.name === 'Juntar Documentos') ||
+                                                (mainData?.properties['Status'].status?.name ===
+                                                    'Proposta aceita' &&
+                                                    mainData?.properties['Status Diligência'].select
+                                                        ?.name === 'Pendência a Sanar')
+                                            }
+                                            onBlur={(e) => {
+                                                e.target.value = formatCurrency(e.target.value);
+                                            }}
+                                            onChange={(e) =>
+                                                changeInputValues('proposal', e.target.value)
+                                            }
+                                            className="ml-2 max-w-35 rounded-md border-none bg-gray-100 py-2 pl-1 pr-2 text-center text-sm font-medium text-body focus-visible:ring-body disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 dark:bg-boxdark-2/50 dark:text-bodydark dark:focus-visible:ring-snow"
+                                        />
+                                    </div>
+                                    <input
+                                        // ref={proposalRangeRef}
+                                        type="range"
+                                        step="0.01"
+                                        disabled={
+                                            (mainData?.properties['Status'].status?.name ===
+                                                'Proposta aceita' &&
+                                                validateIfItsLockedWhenStatusDiligenceBeEqual) ||
+                                            (mainData?.properties['Status'].status?.name ===
+                                                'Proposta aceita' &&
+                                                mainData?.properties['Status Diligência'].select
+                                                    ?.name === 'Juntar Documentos') ||
+                                            (mainData?.properties['Status'].status?.name ===
+                                                'Proposta aceita' &&
+                                                mainData?.properties['Status Diligência'].select
+                                                    ?.name === 'Pendência a Sanar')
+                                        }
+                                        min={
+                                            mainData?.properties['(R$) Proposta Mínima - Celer']
+                                                .number || 0
+                                        }
+                                        max={
+                                            mainData?.properties['(R$) Proposta Máxima - Celer']
+                                                .number || 0
+                                        }
+                                        value={sliderValues.proposal}
+                                        onChange={(e) =>
+                                            handleProposalSliderChange(e.target.value, true)
+                                        }
+                                        className="range-slider w-full disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-50"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="relative flex items-center justify-between gap-5 2xsm:flex-col md:flex-row">
+                                <div className="flex w-full flex-1 flex-col items-center gap-4">
+                                    <div className="flex items-center text-sm font-medium ">
+                                        <p className="text-sm">Comissão:</p>
+                                        <input
+                                            ref={comissionRef}
+                                            type="text"
+                                            disabled={
+                                                (mainData?.properties['Status'].status?.name ===
+                                                    'Proposta aceita' &&
+                                                    validateIfItsLockedWhenStatusDiligenceBeEqual) ||
+                                                (mainData?.properties['Status'].status?.name ===
+                                                    'Proposta aceita' &&
+                                                    mainData?.properties['Status Diligência'].select
+                                                        ?.name === 'Juntar Documentos') ||
+                                                (mainData?.properties['Status'].status?.name ===
+                                                    'Proposta aceita' &&
+                                                    mainData?.properties['Status Diligência'].select
+                                                        ?.name === 'Pendência a Sanar')
+                                            }
+                                            onBlur={(e) => {
+                                                e.target.value = formatCurrency(e.target.value);
+                                            }}
+                                            onChange={(e) =>
+                                                changeInputValues('comission', e.target.value)
+                                            }
+                                            className="ml-2 max-w-35 rounded-md border-none bg-gray-100 py-2 pl-1 pr-2 text-center text-sm font-medium text-body focus-visible:ring-body disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 dark:bg-boxdark-2/50 dark:text-bodydark dark:focus-visible:ring-snow"
+                                        />
+                                    </div>
+                                    <input
+                                        type="range"
+                                        step="0.01"
+                                        disabled={
+                                            (mainData?.properties['Status'].status?.name ===
+                                                'Proposta aceita' &&
+                                                validateIfItsLockedWhenStatusDiligenceBeEqual) ||
+                                            (mainData?.properties['Status'].status?.name ===
+                                                'Proposta aceita' &&
+                                                mainData?.properties['Status Diligência'].select
+                                                    ?.name === 'Juntar Documentos') ||
+                                            (mainData?.properties['Status'].status?.name ===
+                                                'Proposta aceita' &&
+                                                mainData?.properties['Status Diligência'].select
+                                                    ?.name === 'Pendência a Sanar')
+                                        }
+                                        min={
+                                            mainData?.properties['(R$) Comissão Mínima - Celer']
+                                                .number || 0
+                                        }
+                                        max={
+                                            mainData?.properties['(R$) Comissão Máxima - Celer']
+                                                .number || 0
+                                        }
+                                        value={sliderValues.comission}
+                                        onChange={(e) =>
+                                            handleComissionSliderChange(e.target.value, true)
+                                        }
+                                        className="range-slider-reverse [::-webkit-slider-thumb]::-webkit-slider-thumb {background-color: #FFF;} w-full disabled:cursor-not-allowed disabled:bg-gray-100 disabled:opacity-50"
+                                    />
+                                </div>
+                            </div>
+
+                            {errorMessage && (
+                                <div className="absolute -bottom-4 w-full text-center text-xs text-red">
+                                    Valor&#40;res&#41; fora do escopo definido
+                                </div>
+                            )}
+                        </div>
+                        <div className="flex gap-2">
+                            <Button
+                                disabled={isProposalButtonDisabled}
+                                onClick={saveProposalAndComission}
+                                className="h-8 w-full px-2 py-1 text-sm font-medium transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                {savingProposalAndComission ? 'Salvando...' : 'Salvar Oferta'}
+                            </Button>
+                            <Button
+                                isLoading={loading}
+                                onClick={() => handleGeneratePDF()}
+                                className="h-8 w-full px-2 text-sm font-medium transition-all duration-300 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                Gerar Proposta
                             </Button>
                         </div>
-                    </div>
-                    {/* ----> end observations field <----- */}
-                </div>
-            </div>
-            {/* ----> end info <----- */}
+                        {/* Esse componente tem a função apenas de gerar um PDF, por isso hidden */}
+                        <div className="hidden">
+                            <div ref={documentRef} className="bg-[#F4F4F4]">
+                                <PrintPDF
+                                    nomeDoCredor={mainData?.properties['Credor'].title[0]?.text.content}
+                                    valorDaProposta={
+                                        mainData?.properties['Proposta Escolhida - Celer'].number ||
+                                        mainData?.properties['(R$) Proposta Mínima - Celer'].number ||
+                                        0
+                                    }
+                                    nomeDoBroker={first_name + ' ' + last_name}
+                                    fotoDoBroker={profile_picture}
+                                    phone={phone ? phone : null}
+                                />
+                            </div>
+                        </div>
 
-            {/* ----> edit info modal <---- */}
-            <EditOficioBrokerForm mainData={mainData} />
-            {/* ----> end edit info modal <----- */}
-        </div>
+                        {/* separator */}
+
+                        {/* end separator */}
+
+                        {/* ----> observations field <----- */}
+                        <div className="h-full w-full">
+                            <p className="mb-2">Observações:</p>
+                            <div className="relative">
+                                <textarea
+                                    ref={observationRef}
+                                    className="w-full resize-none rounded-md border-stroke placeholder:text-sm dark:border-strokedark dark:bg-boxdark-2/50"
+                                    rows={4}
+                                    placeholder="Insira uma observação"
+                                />
+                                <Button
+                                    variant="ghost"
+                                    onClick={() =>
+                                        handleUpdateObservation(observationRef.current?.value || '')
+                                    }
+                                    className="absolute bottom-3 right-2 z-2 bg-slate-100 px-1 py-1 text-sm hover:bg-slate-200 dark:bg-boxdark-2/50 dark:hover:bg-boxdark-2/70"
+                                >
+                                    {savingObservation ? (
+                                        <AiOutlineLoading className="animate-spin text-lg" />
+                                    ) : (
+                                        <BiSave className="text-lg" />
+                                    )}
+                                </Button>
+                            </div>
+                        </div>
+                        {/* ----> end observations field <----- */}
+                    </div>
+                </div>
+                {/* ----> end info <----- */}
+
+                {/* ----> edit info modal <---- */}
+                <EditOficioBrokerForm mainData={mainData} />
+                {/* ----> end edit info modal <----- */}
+            </div>
+            {showMultiLoader && (
+                <MultiStepLoader
+                    loadingStates={multiLoaderSteps.current}
+                    duration={1200}
+                    reqStatus={proposalReqStatus}
+                    reqType={proposalReqType}
+                    handleClose={handleCloseLoader}
+                    hasEffect={
+                        mainData?.properties['Status'].status?.name !== 'Proposta aceita' &&
+                        checks.are_docs_complete &&
+                        checks.is_cedente_complete &&
+                        checks.is_precatorio_complete
+                    }
+                />
+            )}
+        </>
     );
 };
 

--- a/src/components/Dashboard/Broker.tsx
+++ b/src/components/Dashboard/Broker.tsx
@@ -120,7 +120,7 @@ const Broker: React.FC = (): JSX.Element => {
                     </AccordionItem>
                 </Accordion>
             </div>
-            <div className="col-span-12 mb-5 grid grid-cols-1 items-center gap-5 lg:grid-cols-12">
+            <div className="col-span-12 grid grid-cols-1 items-center gap-5 lg:grid-cols-12">
                 <BrokerQuantityDistributedChart title="Distribuição" response={cardsData} />
                 <BrokerComissionDistribution title="Previsão de Comissão" response={cardsData} />
             </div>

--- a/src/components/Forms/CalcForm.tsx
+++ b/src/components/Forms/CalcForm.tsx
@@ -48,6 +48,7 @@ const CalcForm = ({
         watch,
         control,
         setValue,
+        clearErrors,
         formState: { errors },
     } = formConfigs;
 
@@ -322,7 +323,7 @@ const CalcForm = ({
                         }}
                     />
 
-                    <div className="flex w-full flex-col gap-2 2xsm:col-span-2 sm:col-span-1">
+                    <div className="relative flex w-full flex-col gap-2 2xsm:col-span-2 sm:col-span-1">
                         <label
                             htmlFor="tribunal"
                             className="font-nexa text-xs font-semibold uppercase text-meta-5"
@@ -337,16 +338,28 @@ const CalcForm = ({
                                     (tribunal) => tribunal.nome === value,
                                 )[0];
                                 setValue('tribunal', tribunal.id);
+                                clearErrors('tribunal');
                             }}
                             value={
                                 tribunais.filter((estado) => estado.id === watch('tribunal'))[0]
                                     ?.nome || ''
                             }
-                            register={register('tribunal')}
+                            register={register('tribunal', {
+                                required: {
+                                    value: true,
+                                    message: "Campo obrigatório"
+                                }
+                            })}
                             name="tribunal"
                             placeholder="BUSQUE POR TRIBUNAL"
-                            className="h-[37px] text-sm uppercase"
+                            className={`${errors.tribunal ? '!border-red !ring-0' : 'border-stroke dark:border-strokedark'} h-[37px] text-sm uppercase`}
                         />
+
+                        {errors.tribunal && (
+                            <span className="absolute right-8.5 top-8.5 text-xs font-medium text-red">
+                                {errors.tribunal.message}
+                            </span>
+                        )}
 
                         {/* <select
                             defaultValue={''}
@@ -382,7 +395,7 @@ const CalcForm = ({
                                 <>
                                     <Cleave
                                         {...field}
-                                        className={`w-full rounded-md border-stroke ${error ? 'border-red' : 'dark:border-strokedark'} px-3 py-2 text-sm font-medium dark:bg-boxdark-2 dark:text-bodydark`}
+                                        className={`w-full rounded-md border-stroke ${error ? '!border-red' : 'dark:border-strokedark'} px-3 py-2 text-sm font-medium dark:bg-boxdark-2 dark:text-bodydark`}
                                         options={{
                                             numeral: true,
                                             numeralThousandsGroupStyle: 'thousand',
@@ -594,7 +607,10 @@ const CalcForm = ({
                         </label>
                         <CelerAppCombobox
                             list={opcoesEntesDevedores}
-                            onChangeValue={(value) => setValue('ente_devedor', value)}
+                            onChangeValue={(value) => {
+                                setValue('ente_devedor', value);
+                                clearErrors('ente_devedor')
+                            }}
                             value={
                                 opcoesEntesDevedores.filter(
                                     (estado) => estado === watch('ente_devedor'),
@@ -608,7 +624,7 @@ const CalcForm = ({
                             })}
                             name="ente_devedor"
                             placeholder="BUSQUE PELO ENTE DEVEDOR"
-                            className={`${errors.ente_devedor && '!border-red'} text-sm uppercase`}
+                            className={`${errors.ente_devedor ? '!border-red' : 'border-stroke dark:border-strokedark'} text-sm uppercase`}
                         />
                         {errors.ente_devedor && (
                             <span className="absolute right-8.5 top-8.5 text-xs font-medium text-red">
@@ -640,48 +656,48 @@ const CalcForm = ({
 
                     {((watch('natureza') === 'NÃO TRIBUTÁRIA' || watch('natureza') === undefined) &&
                         watch('incide_contribuicao_previdenciaria') && !entesComTaxaPrevidenciariaPredefinida.includes(watch("ente_devedor") || "")) && (
-                        <div className="flex w-full flex-col gap-2 col-span-2 sm:col-span-1">
-                            <label
-                                title='Percentual de Contribuição Previdenciária (%)'
-                                htmlFor="percentual_de_contribuicao_previdenciaria"
-                                className="truncate font-nexa text-xs font-semibold uppercase text-meta-5"
-                            >
-                                Percentual de Contribuição Previdenciária (%)
-                            </label>
-                            <Controller
-                                name="percentual_de_contribuicao_previdenciaria"
-                                control={control}
-                                defaultValue={0}
-                                rules={{
-                                    min: {
-                                        value: 1,
-                                        message: 'O valor deve ser maior que 0',
-                                    },
-                                }}
-                                render={({ field, fieldState: { error } }) => (
-                                    <>
-                                        <Cleave
-                                            {...field}
-                                            className={`w-full rounded-md border-stroke ${error ? 'border-red' : 'dark:border-strokedark'} px-3 py-2 text-sm font-medium dark:bg-boxdark-2 dark:text-bodydark`}
-                                            options={{
-                                                numeral: true,
-                                                numeralThousandsGroupStyle: 'none',
-                                                numeralDecimalMark: ',',
-                                                prefix: '%',
-                                                tailPrefix: true,
-                                                rawValueTrimPrefix: true,
-                                            }}
-                                        />
-                                        {error && (
-                                            <span className="absolute right-2 top-8.5 text-xs font-medium text-red">
-                                                {error.message}
-                                            </span>
-                                        )}
-                                    </>
-                                )}
-                            />
-                        </div>
-                    )}
+                            <div className="flex w-full flex-col gap-2 col-span-2 sm:col-span-1">
+                                <label
+                                    title='Percentual de Contribuição Previdenciária (%)'
+                                    htmlFor="percentual_de_contribuicao_previdenciaria"
+                                    className="truncate font-nexa text-xs font-semibold uppercase text-meta-5"
+                                >
+                                    Percentual de Contribuição Previdenciária (%)
+                                </label>
+                                <Controller
+                                    name="percentual_de_contribuicao_previdenciaria"
+                                    control={control}
+                                    defaultValue={0}
+                                    rules={{
+                                        min: {
+                                            value: 1,
+                                            message: 'O valor deve ser maior que 0',
+                                        },
+                                    }}
+                                    render={({ field, fieldState: { error } }) => (
+                                        <>
+                                            <Cleave
+                                                {...field}
+                                                className={`w-full rounded-md border-stroke ${error ? 'border-red' : 'dark:border-strokedark'} px-3 py-2 text-sm font-medium dark:bg-boxdark-2 dark:text-bodydark`}
+                                                options={{
+                                                    numeral: true,
+                                                    numeralThousandsGroupStyle: 'none',
+                                                    numeralDecimalMark: ',',
+                                                    prefix: '%',
+                                                    tailPrefix: true,
+                                                    rawValueTrimPrefix: true,
+                                                }}
+                                            />
+                                            {error && (
+                                                <span className="absolute right-2 top-8.5 text-xs font-medium text-red">
+                                                    {error.message}
+                                                </span>
+                                            )}
+                                        </>
+                                    )}
+                                />
+                            </div>
+                        )}
 
                     {watch("ente_devedor") && ((!watch("incide_contribuicao_previdenciaria") && watch("ente_devedor")) ||
                         (!watch("incide_contribuicao_previdenciaria") && !entesComTaxaPrevidenciariaPredefinida.includes(watch("ente_devedor") || "")) || entesComTaxaPrevidenciariaPredefinida.includes(watch("ente_devedor") || "")) && (

--- a/src/components/ui/multi-step-loader.tsx
+++ b/src/components/ui/multi-step-loader.tsx
@@ -1,23 +1,33 @@
 "use client";
 import { cn } from "@/lib/utils";
+import confetti from "canvas-confetti";
 import { AnimatePresence, motion } from "framer-motion";
 import { useState, useEffect } from "react";
 import ReactDOM from 'react-dom'
+import { AiOutlineLoading } from "react-icons/ai";
+import { IoCloseCircleSharp, IoRadioButtonOff } from "react-icons/io5";
+import { Button } from "../Button";
 
-const CheckIcon = ({ className }: { className?: string }) => {
-    return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className={cn("w-6 h-6 ", className)}
-        >
-            <path d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
-        </svg>
-    );
-};
+type MessageTypes = "success_with_pendency" | "success_without_pendency" | "failure" | "proposal_declined"
+
+const returnMessages = {
+    success_with_pendency: {
+        title: "Proposta aceita!",
+        text: "Porém ainda há pontos pendentes para a conclusão da diligência."
+    },
+    success_without_pendency: {
+        title: "Agora é com a gente! 🎉",
+        text: "Nosso setor jurídico dará inicio ao processo de Due Diligence."
+    },
+    proposal_declined: {
+        title: "Proposta cancelada!",
+        text: "Você pode registrar o motivo no campo de observação."
+    },
+    failure: {
+        title: "Ops!",
+        text: "Houve um problema ao completar a requisição. Tente novamente."
+    }
+}
 
 const CheckFilled = ({ className }: { className?: string }) => {
     return (
@@ -36,20 +46,19 @@ const CheckFilled = ({ className }: { className?: string }) => {
     );
 };
 
-type LoadingState = {
-    text: string;
-};
-
 const LoaderCore = ({
     loadingStates,
-    value = 0
+    value = 0,
+    reqStatus
 }: {
-    loadingStates: LoadingState[];
+    loadingStates: string[];
     value?: number;
+    reqStatus?: "success" | "failure" | null
 }) => {
+
     return (
         <div className="flex relative justify-start max-w-xl mx-auto flex-col mt-40">
-            {loadingStates.map((loadingState, index) => {
+            {loadingStates.map((state, index) => {
                 const distance = Math.abs(index - value);
                 const opacity = Math.max(1 - distance * 0.2, 0); // Minimum opacity is 0, keep it 0.2 if you're sane.
 
@@ -63,25 +72,64 @@ const LoaderCore = ({
                     >
                         <div>
                             {index > value && (
-                                <CheckIcon className="text-black dark:text-white" />
+                                <IoRadioButtonOff className="w-6 h-6 text-black dark:text-white" />
                             )}
-                            {index <= value && (
+                            {index < value && (
                                 <CheckFilled
-                                    className={cn(
-                                        "text-black dark:text-white",
-                                        value === index &&
-                                        "text-black dark:text-lime-500 opacity-100"
-                                    )}
+                                    className={cn("text-green-400 dark:text-lime-500")}
                                 />
                             )}
+                            {index === value && (
+                                <>
+                                    {(value === loadingStates.length - 1 || value === loadingStates.length - 2) && 
+                                    reqStatus === "success" && (
+                                        <CheckFilled
+                                            className={cn("text-green-400 dark:text-lime-500")}
+                                        />
+                                    )}
+                                    {(value === loadingStates.length - 1 && reqStatus === "failure") && (
+                                        <IoCloseCircleSharp
+                                            className={cn(
+                                                "w-6 h-6 text-red opacity-100"
+                                            )}
+                                        />
+                                    )}
+                                    {(value === index && !reqStatus || value < loadingStates.length - 2) && (
+                                        <AiOutlineLoading className="w-6 h-6 animate-spin text-black dark:text-white" />
+                                    )}
+                                </>
+                            )}
+                            {/* {(index <= value && reqStatus) && (
+                                <>
+                                    {reqStatus === "failure" && (
+                                        <IoCloseCircleSharp
+                                            className={cn(
+                                                "text-black dark:text-white",
+                                                value === index &&
+                                                "text-red opacity-100"
+                                            )}
+                                        />
+                                    )}
+                                    {reqStatus === "success" && (
+                                        <CheckFilled
+                                            className={cn(
+                                                "text-black dark:text-white",
+                                                value === index &&
+                                                "text-black dark:text-lime-500 opacity-100"
+                                            )}
+                                        />
+                                    )}
+                                </>
+                            )} */}
                         </div>
                         <span
-                            className={cn(
-                                "text-black dark:text-white",
-                                value === index && "text-black dark:text-lime-500 opacity-100"
-                            )}
+                            className={`text-black dark:text-white 
+                                ${value > index && "text-green-400 dark:!text-lime-500 opacity-100"} 
+                                ${(value === index && value === loadingStates.length - 1 && reqStatus === "failure") && "text-red dark:!text-red opacity-100"} 
+                                ${(value === loadingStates.length - 1 || value === loadingStates.length - 2) && 
+                                    reqStatus === "success" && "text-green-400 dark:!text-lime-500 opacity-100"}`}
                         >
-                            {loadingState.text}
+                            {state}
                         </span>
                     </motion.div>
                 );
@@ -92,27 +140,59 @@ const LoaderCore = ({
 
 export const MultiStepLoader = ({
     loadingStates,
-    loading,
     duration = 2000,
-    loop = true,
-    reqStatus
+    reqStatus,
+    reqType,
+    handleClose,
+    hasEffect = false
 }: {
-    loadingStates: LoadingState[];
-    loading?: boolean;
+    loadingStates: string[];
     duration?: number;
-    loop?: boolean;
-    reqStatus?: "success" | "failure"
+    reqStatus: "success" | "failure" | null;
+    reqType: "accept" | "decline" | null;
+    handleClose?: () => void;
+    hasEffect: boolean | null
 }) => {
     const [currentState, setCurrentState] = useState(0);
+    const [isFinished, setIsFinished] = useState<boolean>(false);
+    const [messageType, setMessageType] = useState<MessageTypes>("success_with_pendency");
 
     useEffect(() => {
-        if (!loading) {
-            setCurrentState(0);
+        // if (!loading) {
+        //     setCurrentState(0);
+        //     return;
+        // }
+
+        if (currentState >= loadingStates.length - 1 && reqStatus) {
+            if (reqStatus === "success") {
+                if (reqType === "accept") {
+                    if (hasEffect) {
+                        confetti({
+                            spread: 180,
+                            particleCount: 300,
+                            origin: {
+                                y: 0.5,
+                            },
+                        });
+                        setMessageType("success_without_pendency");
+                    } else {
+                        setMessageType("success_with_pendency");
+                    } 
+                } else {
+                    setMessageType("proposal_declined");
+                }
+            } else {
+                setMessageType("failure");
+            }
+
+            setTimeout(() => {
+                setIsFinished(true)
+            }, 1500)
             return;
         }
 
         const timeout = setTimeout(() => {
-            if (reqStatus === "success") {
+            if (reqStatus) {
                 setCurrentState((prevState) =>
                     Math.min(prevState + 1, loadingStates.length - 1)
                 );
@@ -124,31 +204,45 @@ export const MultiStepLoader = ({
         }, duration);
 
         return () => clearTimeout(timeout);
-    }, [currentState, loading, loop, loadingStates.length, duration]);
+    }, [currentState, reqStatus, loadingStates.length, duration]);
 
     return (
         ReactDOM.createPortal(
             <AnimatePresence mode="wait">
-                {loading && (
-                    <motion.div
-                        initial={{
-                            opacity: 0,
-                        }}
-                        animate={{
-                            opacity: 1,
-                        }}
-                        exit={{
-                            opacity: 0,
-                        }}
-                        className="w-full h-full fixed inset-0 z-[100] flex items-center justify-center backdrop-blur-2xl"
-                    >
+                <motion.div
+                    initial={{
+                        opacity: 0,
+                    }}
+                    animate={{
+                        opacity: 1,
+                    }}
+                    exit={{
+                        opacity: 0,
+                    }}
+                    className="w-full h-full fixed inset-0 z-[100] flex items-center justify-center backdrop-blur-2xl"
+                >
+                    <div className="relative z-50 flex items-center justify-center">
                         <div className="h-96  relative">
-                            <LoaderCore value={currentState} loadingStates={loadingStates} />
+                            <LoaderCore value={currentState} loadingStates={loadingStates} reqStatus={reqStatus} />
                         </div>
 
-                        <div className="bg-gradient-to-t inset-x-0 z-20 bottom-0 bg-white dark:bg-[#000] h-full absolute [mask-image:radial-gradient(900px_at_center,transparent_30%,white)]" />
-                    </motion.div>
-                )}
+                        <div className={`${isFinished && "py-2 px-20 max-w-fit"} min-h-80 max-w-0 transition-all duration-500 ease-in-out overflow-hidden`}>
+                            <h2 className="text-[clamp(1.5rem,5vw,3rem)] mb-5 text-black-2 dark:text-snow font-medium">
+                                {returnMessages[messageType as keyof typeof returnMessages].title}
+                            </h2>
+                            <p className="text-black-2 dark:text-gray-300">
+                            {returnMessages[messageType as keyof typeof returnMessages].text}
+                            </p>
+                            <Button
+                                className="mt-5"
+                                onClick={handleClose}>
+                                Fechar
+                            </Button>
+                        </div>
+                    </div>
+
+                    <div className="bg-gradient-to-t inset-x-0 z-20 bottom-0 bg-white dark:bg-[#000] h-full absolute [mask-image:radial-gradient(900px_at_center,transparent_30%,white)]" />
+                </motion.div>
             </AnimatePresence>,
             document.body
         )

--- a/src/functions/timer/sleep.ts
+++ b/src/functions/timer/sleep.ts
@@ -1,0 +1,1 @@
+export const sleep = async (s: number) => new Promise(res => setTimeout(res, s * 1000));


### PR DESCRIPTION
# Descrição

- :tada: Adicionado multistep loader na view broker para estado de carregamento do check de proposta aceita.

Para esse novo componente, existem algumas observações:

> O componente foi construído baseado na necessidade do processo de aceitar/negar uma proposta somente da view `BROKER`.
> O componente pode apresentar mal-funcionamento se implementado em outro local para outra finalidade.

### Propriedades do componente

| Propiedade | Tipo | Descrição |
|------|------|-----------|
| loadingStates | string[] | Estados (passos) que serão apresentados no decorrer do procedimento |
| duration | number (opcional) | Duração (em milisegundos) de cada estado. Valor padrão `2000` |
| reqStatus | "success"/"failure"/null | Status da requisição de proposta |
| reqType | "accept"/"decline"/null | Tipo da requisição de proposta (pois pode tanto aceitar, quanto negar) |
| handleClose | () => void | Função responsável por fechar o multiloader |
| hasEffect | boolean/null | Se `true`, dispara um efeito de confetes no fim da requisiçao |